### PR TITLE
[COH-17784][Feature] Show capture screenshot command in inspector

### DIFF
--- a/front_end/core/root/Runtime.ts
+++ b/front_end/core/root/Runtime.ts
@@ -567,6 +567,6 @@ export enum ExperimentName {
 // TODO(crbug.com/1167717): Make this a const enum again
 // eslint-disable-next-line rulesdir/const_enum
 export enum ConditionName {
-  CAN_DOCK = 'can_dock',
+  CAN_DOCK = '!can_dock',
   NOT_SOURCES_HIDE_ADD_FOLDER = '!sources.hide_add_folder',
 }

--- a/front_end/core/root/Runtime.ts
+++ b/front_end/core/root/Runtime.ts
@@ -567,6 +567,9 @@ export enum ExperimentName {
 // TODO(crbug.com/1167717): Make this a const enum again
 // eslint-disable-next-line rulesdir/const_enum
 export enum ConditionName {
-  CAN_DOCK = '!can_dock',
+  CAN_DOCK = 'can_dock',
   NOT_SOURCES_HIDE_ADD_FOLDER = '!sources.hide_add_folder',
+  // COHERENT BEGIN
+  COHERENT_CAN_DOCK = "!can_dock"
+  // COHERENT END
 }

--- a/front_end/core/sdk/ScreenCaptureModel.ts
+++ b/front_end/core/sdk/ScreenCaptureModel.ts
@@ -42,8 +42,9 @@ export class ScreenCaptureModel extends SDKModel implements ProtocolProxyApi.Pag
       format: Protocol.Page.CaptureScreenshotRequestFormat, quality: number,
       clip?: Protocol.Page.Viewport): Promise<string|null> {
     await OverlayModel.muteHighlight();
+    // TODO: Implement working fromSurface and captureBeyondViewport params and enable them here
     const result = await this.agent.invoke_captureScreenshot(
-        {format, quality, clip, fromSurface: true, captureBeyondViewport: true});
+        {format, quality, clip, /* fromSurface: true, captureBeyondViewport: true */});
     await OverlayModel.unmuteHighlight();
     return result.data;
   }

--- a/front_end/core/sdk/ScreenCaptureModel.ts
+++ b/front_end/core/sdk/ScreenCaptureModel.ts
@@ -44,7 +44,11 @@ export class ScreenCaptureModel extends SDKModel implements ProtocolProxyApi.Pag
     await OverlayModel.muteHighlight();
     // TODO: Implement working fromSurface and captureBeyondViewport params and enable them here
     const result = await this.agent.invoke_captureScreenshot(
-        {format, quality, clip, /* fromSurface: true, captureBeyondViewport: true */});
+        {format, quality, clip,            
+          //COHERENT BEGIN
+          /* fromSurface: true, captureBeyondViewport: true */
+          //COHERENT END 
+       });
     await OverlayModel.unmuteHighlight();
     return result.data;
   }

--- a/front_end/panels/elements/elements-meta.ts
+++ b/front_end/panels/elements/elements-meta.ts
@@ -344,16 +344,17 @@ UI.ActionRegistration.registerActionExtension({
   ],
 });
 
-UI.ActionRegistration.registerActionExtension({
-  actionId: 'elements.capture-area-screenshot',
-  async loadActionDelegate() {
-    const Elements = await loadElementsModule();
-    return Elements.InspectElementModeController.ToggleSearchActionDelegate.instance();
-  },
-  condition: Root.Runtime.ConditionName.CAN_DOCK,
-  title: i18nLazyString(UIStrings.captureAreaScreenshot),
-  category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
-});
+// TODO: Implement and enable capture area screenshot
+// UI.ActionRegistration.registerActionExtension({
+//   actionId: 'elements.capture-area-screenshot',
+//   async loadActionDelegate() {
+//     const Elements = await loadElementsModule();
+//     return Elements.InspectElementModeController.ToggleSearchActionDelegate.instance();
+//   },
+//   condition: Root.Runtime.ConditionName.CAN_DOCK,
+//   title: i18nLazyString(UIStrings.captureAreaScreenshot),
+//   category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
+// });
 
 UI.ActionRegistration.registerActionExtension({
   category: UI.ActionRegistration.ActionCategory.ELEMENTS,

--- a/front_end/panels/elements/elements-meta.ts
+++ b/front_end/panels/elements/elements-meta.ts
@@ -344,17 +344,17 @@ UI.ActionRegistration.registerActionExtension({
   ],
 });
 
-// TODO: Implement and enable capture area screenshot
-// UI.ActionRegistration.registerActionExtension({
-//   actionId: 'elements.capture-area-screenshot',
-//   async loadActionDelegate() {
-//     const Elements = await loadElementsModule();
-//     return Elements.InspectElementModeController.ToggleSearchActionDelegate.instance();
-//   },
-//   condition: Root.Runtime.ConditionName.CAN_DOCK,
-//   title: i18nLazyString(UIStrings.captureAreaScreenshot),
-//   category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
-// });
+// TODO: Implement and enable capture area screenshot by using COHERENT_CAN_DOCK
+UI.ActionRegistration.registerActionExtension({
+  actionId: 'elements.capture-area-screenshot',
+  async loadActionDelegate() {
+    const Elements = await loadElementsModule();
+    return Elements.InspectElementModeController.ToggleSearchActionDelegate.instance();
+  },
+  condition: Root.Runtime.ConditionName.CAN_DOCK,
+  title: i18nLazyString(UIStrings.captureAreaScreenshot),
+  category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
+});
 
 UI.ActionRegistration.registerActionExtension({
   category: UI.ActionRegistration.ActionCategory.ELEMENTS,

--- a/front_end/panels/emulation/emulation-meta.ts
+++ b/front_end/panels/emulation/emulation-meta.ts
@@ -110,27 +110,28 @@ UI.ActionRegistration.registerActionExtension({
   title: i18nLazyString(UIStrings.captureScreenshot),
 });
 
-UI.ActionRegistration.registerActionExtension({
-  actionId: 'emulation.capture-full-height-screenshot',
-  category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
-  async loadActionDelegate() {
-    const Emulation = await loadEmulationModule();
-    return Emulation.DeviceModeWrapper.ActionDelegate.instance();
-  },
-  condition: Root.Runtime.ConditionName.CAN_DOCK,
-  title: i18nLazyString(UIStrings.captureFullSizeScreenshot),
-});
+// TODO: Implement and enable capture full size screenshot and capture node screenshot
+// UI.ActionRegistration.registerActionExtension({
+//   actionId: 'emulation.capture-full-height-screenshot',
+//   category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
+//   async loadActionDelegate() {
+//     const Emulation = await loadEmulationModule();
+//     return Emulation.DeviceModeWrapper.ActionDelegate.instance();
+//   },
+//   condition: Root.Runtime.ConditionName.CAN_DOCK,
+//   title: i18nLazyString(UIStrings.captureFullSizeScreenshot),
+// });
 
-UI.ActionRegistration.registerActionExtension({
-  actionId: 'emulation.capture-node-screenshot',
-  category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
-  async loadActionDelegate() {
-    const Emulation = await loadEmulationModule();
-    return Emulation.DeviceModeWrapper.ActionDelegate.instance();
-  },
-  condition: Root.Runtime.ConditionName.CAN_DOCK,
-  title: i18nLazyString(UIStrings.captureNodeScreenshot),
-});
+// UI.ActionRegistration.registerActionExtension({
+//   actionId: 'emulation.capture-node-screenshot',
+//   category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
+//   async loadActionDelegate() {
+//     const Emulation = await loadEmulationModule();
+//     return Emulation.DeviceModeWrapper.ActionDelegate.instance();
+//   },
+//   condition: Root.Runtime.ConditionName.CAN_DOCK,
+//   title: i18nLazyString(UIStrings.captureNodeScreenshot),
+// });
 
 Common.Settings.registerSettingExtension({
   category: Common.Settings.SettingCategory.MOBILE,

--- a/front_end/panels/emulation/emulation-meta.ts
+++ b/front_end/panels/emulation/emulation-meta.ts
@@ -106,32 +106,34 @@ UI.ActionRegistration.registerActionExtension({
     const Emulation = await loadEmulationModule();
     return Emulation.DeviceModeWrapper.ActionDelegate.instance();
   },
-  condition: Root.Runtime.ConditionName.CAN_DOCK,
+  // COHERENT BEGIN
+  condition: Root.Runtime.ConditionName.COHERENT_CAN_DOCK,
+  // COHERENT END
   title: i18nLazyString(UIStrings.captureScreenshot),
 });
 
-// TODO: Implement and enable capture full size screenshot and capture node screenshot
-// UI.ActionRegistration.registerActionExtension({
-//   actionId: 'emulation.capture-full-height-screenshot',
-//   category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
-//   async loadActionDelegate() {
-//     const Emulation = await loadEmulationModule();
-//     return Emulation.DeviceModeWrapper.ActionDelegate.instance();
-//   },
-//   condition: Root.Runtime.ConditionName.CAN_DOCK,
-//   title: i18nLazyString(UIStrings.captureFullSizeScreenshot),
-// });
+// TODO: Implement and enable capture full size screenshot and capture node screenshot by using COHERENT_CAN_DOCK
+UI.ActionRegistration.registerActionExtension({
+  actionId: 'emulation.capture-full-height-screenshot',
+  category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
+  async loadActionDelegate() {
+    const Emulation = await loadEmulationModule();
+    return Emulation.DeviceModeWrapper.ActionDelegate.instance();
+  },
+  condition: Root.Runtime.ConditionName.CAN_DOCK,
+  title: i18nLazyString(UIStrings.captureFullSizeScreenshot),
+});
 
-// UI.ActionRegistration.registerActionExtension({
-//   actionId: 'emulation.capture-node-screenshot',
-//   category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
-//   async loadActionDelegate() {
-//     const Emulation = await loadEmulationModule();
-//     return Emulation.DeviceModeWrapper.ActionDelegate.instance();
-//   },
-//   condition: Root.Runtime.ConditionName.CAN_DOCK,
-//   title: i18nLazyString(UIStrings.captureNodeScreenshot),
-// });
+UI.ActionRegistration.registerActionExtension({
+  actionId: 'emulation.capture-node-screenshot',
+  category: UI.ActionRegistration.ActionCategory.SCREENSHOT,
+  async loadActionDelegate() {
+    const Emulation = await loadEmulationModule();
+    return Emulation.DeviceModeWrapper.ActionDelegate.instance();
+  },
+  condition: Root.Runtime.ConditionName.CAN_DOCK,
+  title: i18nLazyString(UIStrings.captureNodeScreenshot),
+});
 
 Common.Settings.registerSettingExtension({
   category: Common.Settings.SettingCategory.MOBILE,
@@ -202,7 +204,9 @@ Common.AppProvider.registerAppProvider({
     const Emulation = await loadEmulationModule();
     return Emulation.AdvancedApp.AdvancedAppProvider.instance();
   },
-  condition: Root.Runtime.ConditionName.CAN_DOCK,
+  // COHERENT BEGIN
+  condition: Root.Runtime.ConditionName.COHERENT_CAN_DOCK,
+  // COHERENT END
   order: 0,
 });
 


### PR DESCRIPTION
JIRA: https://coherent-labs.atlassian.net/jira/software/c/projects/COH/issues/COH-17784?filter=myopenissues

Related PRs: https://github.com/CoherentLabs/cohtml/pull/2669

Explanation: I made the [Page.captureScreenshot](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot) work in my CoHTML PR. The way this protocol function is called in the Chrome Inspector, aside from sending raw requests, is by clicking on the 3 dots in the upper-right corner, selecting run commands and then typing "capture screenshot" and selecting one of the commands:

![image](https://github.com/CoherentLabs/devtools-frontend-fork/assets/146723587/bdf35b52-e35e-4f80-905c-663c166f8be7)

Originally, these 4 commands did not show in our inspector. I investigated why that is the case and found out the following:
1) The capture screenshot commands are registered as actions via the `UI.ActionRegistration.registerActionExtension` function. When registered, these actions are given a condition. The condition is `Root.Runtime.ConditionName.CAN_DOCK`, where `CAN_DOCK` is "can_dock".
 
2) When the command menu is opened, the available commands to show are filtered. This is done [here](https://github.com/CoherentLabs/devtools-frontend-fork/blob/cohtml_master/front_end/ui/legacy/ActionRegistry.ts#L35) and [here](https://github.com/CoherentLabs/devtools-frontend-fork/blob/cohtml_master/front_end/ui/legacy/ActionRegistration.ts#L157). The filtering function is [this](https://github.com/CoherentLabs/devtools-frontend-fork/blob/cohtml_master/front_end/core/root/Runtime.ts#L172)

3) For condition="can_dock", the filtering function would return false and the capture screenshot commands would be filtered out.  When changing it to "!can_dock", the filter returns true and the commands (the 1 command, more info below) are shown: 

![image](https://github.com/CoherentLabs/devtools-frontend-fork/assets/146723587/3f949454-5824-4db9-bd16-42b6c45f6df0)

Instead of changing the original `CAN_DOCK`, I added a new `COHERENT_CAN_DOCK` and used that as the condition for the proper "Capture screenshot" command.

4) There is only 1 capture screenshot command shown here because I used `COHERENT_CAN_DOCK` for only 1 command. I did not show the other commands because we do not support their functionality for various reasons:

    4.1) "Capture area screenshot" in Chrome changes our cursor and lets us select the area to screenshot by clicking LMB and 
            dragging across the page. We do not support such functionality in our inspector.
            
    4.2) "Capture node screenshot" and "Capture full size screenshot" are not supported because we do not support capturing 
            contents of the page that are outside the viewport, whereas these commands do. For example, if the page is scrollable 
            because of an element clipping the viewport and we do "Capture full size screenshot" in Chrome, that would give us the 
            whole page, including everything that could be seen by scrolling. We do not support this in CoHTML. Same thing happens 
            if we try to capture a node that is clipping the viewport. [More info here.](https://github.com/CoherentLabs/cohtml/pull/2669)
            
5) In order for the `Capture screenshot` command to actually do anything, we need to have the emulation module created and enabled as well. This is also governed by the `CAN_DOCK` condition, so we change it to `COHERENT_CAN_DOCK` to enable it.

    5.1) A side effect of this change is that now this button in the DevTools inspector doesn't do anything. It never used to work properly anyway, so that's fine:
    
![image](https://github.com/CoherentLabs/devtools-frontend-fork/assets/146723587/ac9ca94c-a98d-418c-a7ff-d1d59f1d3f9b)

6) In order for the `Capture screenshot` command to work correctly, when sending the function request to the inspector agents, we need to remove the parameters `fromSurface: true` and `captureBeyondViewport: true`. We do not support these parameters for `Page.captureScreenshot` and return an error message instead. [So I commented them out in here.
](https://github.com/CoherentLabs/devtools-frontend-fork/blob/feature/inspector-capture-screenshot-command/front_end/core/sdk/ScreenCaptureModel.ts#L48)