### PR TITLE
[Enhancement][COH-20890] Performance Monitor metrics relevant to Gameface

### DIFF
--- a/front_end/core/sdk/PerformanceMetricsModel.ts
+++ b/front_end/core/sdk/PerformanceMetricsModel.ts
@@ -24,8 +24,18 @@ export class PerformanceMetricsModel extends SDKModel {
     this.metricModes = new Map([
       ['TaskDuration', MetricMode.CumulativeTime],
       ['ScriptDuration', MetricMode.CumulativeTime],
-      ['LayoutDuration', MetricMode.CumulativeTime],
-      ['RecalcStyleDuration', MetricMode.CumulativeTime],
+      // COHERENT BEGIN: Do not consider LayoutDuration/RecalcStyleDuration as CumulativeTime
+      // NOTE: CumulativeTime is kind of useless, maybe that's why by default Chrome doesn't
+      // visualize any duration metric in the Performance Monitor.
+      // It basically measures what fraction does an event take between 2 polls.
+      // For example, if we have a 600ms poll interval and a 30ms frame, 5ms Layout per frame,
+      // we'll see the number 0.16 (5*20 frames between the polls / 600ms poll interval) for LayoutDuration,
+      // which is totally meaningless.
+      // What we want to see is the 5ms - the average time a Layout takes between polls.
+      // We'll get that by sending metrics of Default mode (NOT CumulativeTime) that are being reset between polls.
+      //['LayoutDuration', MetricMode.CumulativeTime],
+      //['RecalcStyleDuration', MetricMode.CumulativeTime],
+      // COHERENT END
       ['LayoutCount', MetricMode.CumulativeCount],
       ['RecalcStyleCount', MetricMode.CumulativeCount],
     ]);

--- a/front_end/panels/performance_monitor/PerformanceMonitor.ts
+++ b/front_end/panels/performance_monitor/PerformanceMonitor.ts
@@ -53,6 +53,14 @@ const UIStrings = {
   *@description Text in Performance Monitor of the Performance monitor tab
   */
   styleRecalcsSec: 'Style recalcs / sec',
+  // COHERENT BEGIN: Add new counter names
+  advanceDur: 'Advance ms',
+  stylingDur: 'Styling ms',
+  layoutDur: 'Layout ms',
+  recordRenderingDur: 'Record rendering ms',
+  paintFrontendDur: 'Paint frontend ms',
+  paintBackendDur: 'Paint backend ms',
+  // COHERENT END
 };
 const str_ = i18n.i18n.registerUIStrings('panels/performance_monitor/PerformanceMonitor.ts', UIStrings);
 const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
@@ -450,8 +458,13 @@ export class ControlPane extends Common.ObjectWrapper.ObjectWrapper {
     super();
     this.element = parent.createChild('div', 'perfmon-control-pane');
 
+    // COHERENT BEGIN: Change the defaults for enabled charts
+//    this.enabledChartsSetting = Common.Settings.Settings.instance().createSetting(
+//        'perfmonActiveIndicators2', ['TaskDuration', 'JSHeapTotalSize', 'Nodes']);
     this.enabledChartsSetting = Common.Settings.Settings.instance().createSetting(
-        'perfmonActiveIndicators2', ['TaskDuration', 'JSHeapTotalSize', 'Nodes']);
+        'perfmonActiveIndicators2', ['AdvanceDuration', 'StylingDuration', 'LayoutDuration',
+          'RecordRenderingDuration', 'PaintFrontendDuration', 'PaintBackendDuration', 'JSHeapTotalSize', 'Nodes']);
+    // COHERENT END
     this.enabledCharts = new Set(this.enabledChartsSetting.get());
 
     const defaults = {
@@ -463,6 +476,8 @@ export class ControlPane extends Common.ObjectWrapper.ObjectWrapper {
       stacked: undefined,
     };
 
+    // COHERENT BEGIN: Make new charts relevant to Gameface
+    /*
     this.chartsInfo = [
       {
         ...defaults,
@@ -502,6 +517,35 @@ export class ControlPane extends Common.ObjectWrapper.ObjectWrapper {
         metrics: [{name: 'RecalcStyleCount', color: 'deeppink'}],
       },
     ];
+    */
+    this.chartsInfo = [
+      {...defaults, title: i18nString(UIStrings.advanceDur), metrics: [{name: 'AdvanceDuration', color: 'darkkhaki'}]},
+      {...defaults, title: i18nString(UIStrings.stylingDur), metrics: [{name: 'StylingDuration', color: 'gold'}]},
+      {...defaults, title: i18nString(UIStrings.layoutDur), metrics: [{name: 'LayoutDuration', color: 'indianred'}]},
+      {...defaults, title: i18nString(UIStrings.recordRenderingDur), metrics: [{name: 'RecordRenderingDuration', color: 'lightsalmon'}]},
+      {...defaults, title: i18nString(UIStrings.paintFrontendDur), metrics: [{name: 'PaintFrontendDuration', color: 'darkblue'}]},
+      {...defaults, title: i18nString(UIStrings.paintBackendDur), metrics: [{name: 'PaintBackendDuration', color: 'darkcyan'}]},
+      {
+        ...defaults,
+        title: i18nString(UIStrings.jsHeapSize),
+        metrics: [{name: 'JSHeapTotalSize', color: '#99f'}, {name: 'JSHeapUsedSize', color: 'blue'}],
+        format: Format.Bytes,
+        color: 'blue',
+      },
+      {...defaults, title: i18nString(UIStrings.domNodes), metrics: [{name: 'Nodes', color: 'green'}]},
+      {
+        ...defaults,
+        title: i18nString(UIStrings.jsEventListeners),
+        metrics: [{name: 'JSEventListeners', color: 'yellowgreen'}],
+      },
+      {...defaults, title: i18nString(UIStrings.layoutsSec), metrics: [{name: 'LayoutCount', color: 'hotpink'}]},
+      {
+        ...defaults,
+        title: i18nString(UIStrings.styleRecalcsSec),
+        metrics: [{name: 'RecalcStyleCount', color: 'deeppink'}],
+      },
+    ];
+    // COHERENT END
     for (const info of this.chartsInfo) {
       if (info.color) {
         info.color = ThemeSupport.ThemeSupport.instance().patchColorText(


### PR DESCRIPTION
The Performance Monitor panel polls the browser engine (in our case Gameface) at a certain interval (500ms by default).

Gameface returns a set of metrics using the Chrome DevTools Protocol and they are visualized.

The changes are basically adding some counters and ditching the `CumulativeTime` mode since it's meaningless.

CoHTML changes can be seen here: https://github.com/CoherentLabs/cohtml/tree/enhancement/real_time_overlay_profiler (specifically the InspectorPerformanceAgent.cpp file)

<img width="1317" height="821" alt="image" src="https://github.com/user-attachments/assets/b654c32d-e3e6-4701-b15d-a4b108179cab" />
