### PR TITLE
Data binding tabs and highligh setup

### DIFF
--- a/config/gni/devtools_grd_files.gni
+++ b/config/gni/devtools_grd_files.gni
@@ -921,6 +921,7 @@ grd_files_debug_sources = [
   "front_end/panels/elements/components/nodeText.css.js",
   "front_end/panels/elements/components/queryContainer.css.js",
   "front_end/panels/elements/components/stylePropertyEditor.css.js",
+  "front_end/panels/elements/components/dataBindingProperty.css.js",
   "front_end/panels/elements/computedStyleSidebarPane.css.js",
   "front_end/panels/elements/computedStyleWidgetTree.css.js",
   "front_end/panels/elements/domLinkifier.css.js",

--- a/front_end/entrypoints/inspector_main/BUILD.gn
+++ b/front_end/entrypoints/inspector_main/BUILD.gn
@@ -11,6 +11,7 @@ devtools_module("inspector_main") {
     "InspectorMain.ts",
     "RenderingOptions.ts",
     "CohtmlPanel.ts",
+    "DataBindingModelsPanel.ts",
   ]
 
   deps = [
@@ -23,6 +24,7 @@ devtools_module("inspector_main") {
     "../../panels/mobile_throttling:bundle",
     "../../ui/legacy:bundle",
     "../../ui/legacy/components/utils:bundle",
+    "../../ui/legacy/components/object_ui:bundle",
   ]
 }
 

--- a/front_end/entrypoints/inspector_main/DataBindingModelsPanel.ts
+++ b/front_end/entrypoints/inspector_main/DataBindingModelsPanel.ts
@@ -1,0 +1,576 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/*
+ * Copyright (C) IBM Corp. 2009  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of IBM Corp. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* eslint-disable rulesdir/no_underscored_properties */
+
+import * as Common from '../../core/common/common.js';
+import * as Host from '../../core/host/host.js';
+import * as i18n from '../../core/i18n/i18n.js';
+import * as Platform from '../../core/platform/platform.js';
+import * as SDK from '../../core/sdk/sdk.js';
+import * as ObjectUI from '../../ui/legacy/components/object_ui/object_ui.js';
+import * as Components from '../../ui/legacy/components/utils/utils.js';
+import * as UI from '../../ui/legacy/legacy.js';
+import type * as Protocol from '../../generated/protocol.js';
+
+// import {UISourceCodeFrame} from '../sources/UISourceCodeFrame.js';
+
+const UIStrings = {
+    /**
+    *@description A context menu item in the Watch Expressions Sidebar Pane of the Sources panel
+    */
+    addWatchExpression: 'Add watch expression',
+    /**
+    *@description Tooltip/screen reader label of a button in the Sources panel that refreshes all watch expressions.
+    */
+    refreshWatchExpressions: 'Refresh watch expressions',
+    /**
+    *@description Empty element text content in Watch Expressions Sidebar Pane of the Sources panel
+    */
+    noWatchExpressions: 'No watch expressions',
+    /**
+    *@description A context menu item in the Watch Expressions Sidebar Pane of the Sources panel
+    */
+    deleteAllWatchExpressions: 'Delete all watch expressions',
+    /**
+    *@description A context menu item in the Watch Expressions Sidebar Pane of the Sources panel
+    */
+    addPropertyPathToWatch: 'Add property path to watch',
+    /**
+    *@description A context menu item in the Watch Expressions Sidebar Pane of the Sources panel
+    */
+    deleteWatchExpression: 'Delete watch expression',
+    /**
+    *@description Value element text content in Watch Expressions Sidebar Pane of the Sources panel
+    */
+    notAvailable: '<not available>',
+    /**
+    *@description A context menu item in the Watch Expressions Sidebar Pane of the Sources panel and Network pane request.
+    */
+    copyValue: 'Copy value',
+    autoUpdateBindModels: 'When enabled the models will be automatically updated',
+    watchForModelChanges: 'Watch for model changes'
+};
+const str_ = i18n.i18n.registerUIStrings('panels/sources/WatchExpressionsSidebarPane.ts', UIStrings);
+const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
+let dataBindingModelsViewInstance: DataBindingModelsPanelView;
+
+export class DataBindingModelsPanelView extends UI.ThrottledWidget.ThrottledWidget implements
+    UI.ActionRegistration.ActionDelegate, UI.Toolbar.ItemsProvider, UI.ContextMenu.Provider {
+    _watchExpressions: WatchExpression[];
+    _emptyElement!: HTMLElement;
+    _watchExpressionsSetting: Common.Settings.Setting<string[]>;
+    _treeOutline: ObjectUI.ObjectPropertiesSection.ObjectPropertiesSectionsTreeOutline;
+    _expandController: ObjectUI.ObjectPropertiesSection.ObjectPropertiesSectionsTreeExpandController;
+    _linkifier: Components.Linkifier.Linkifier;
+    _autoUpdateBindModelsSetting: Common.Settings.Setting<boolean>;
+    _toolbarItems: (UI.Toolbar.ToolbarButton | UI.Toolbar.ToolbarSettingCheckbox)[];
+    private constructor() {
+        super(true);
+        this._toolbarItems = [];
+
+        const refreshButton =
+            new UI.Toolbar.ToolbarButton(i18nString(UIStrings.refreshWatchExpressions), 'largeicon-refresh');
+        refreshButton.addEventListener(UI.Toolbar.ToolbarButton.Events.Click, this.update, this);
+        this._toolbarItems.push(refreshButton);
+
+        this._autoUpdateBindModelsSetting = Common.Settings.Settings.instance().moduleSetting('autoUpdateBindModels');
+        this._autoUpdateBindModelsSetting.addChangeListener(this.update.bind(this));
+
+        this._toolbarItems.push(new UI.Toolbar.ToolbarSettingCheckbox(
+            this._autoUpdateBindModelsSetting, i18nString(UIStrings.autoUpdateBindModels), i18nString(UIStrings.watchForModelChanges)));
+
+        this.registerRequiredCSS('ui/legacy/components/object_ui/objectValue.css');
+        this.registerRequiredCSS('panels/sources/watchExpressionsSidebarPane.css');
+
+        // TODO(szuend): Replace with a Set once the web test
+        // panels/sources/debugger-ui/watch-expressions-preserve-expansion.js is either converted
+        // to an e2e test or no longer accesses this variable directly.
+        this._watchExpressions = [];
+        this._watchExpressionsSetting =
+            Common.Settings.Settings.instance().createLocalSetting<string[]>('dataBindingModels', []);
+        this._watchExpressionsSetting.set(['inventoryModel'])
+        this.contentElement.classList.add('watch-expressions');
+        this.contentElement.addEventListener('contextmenu', this._contextMenu.bind(this), false);
+        this._treeOutline = new ObjectUI.ObjectPropertiesSection.ObjectPropertiesSectionsTreeOutline();
+        this._treeOutline.registerRequiredCSS('panels/sources/watchExpressionsSidebarPane.css');
+        this._treeOutline.setShowSelectionOnKeyboardFocus(/* show */ true);
+        this._expandController =
+            new ObjectUI.ObjectPropertiesSection.ObjectPropertiesSectionsTreeExpandController(this._treeOutline);
+
+        UI.Context.Context.instance().addFlavorChangeListener(SDK.RuntimeModel.ExecutionContext, this.update, this);
+        UI.Context.Context.instance().addFlavorChangeListener(SDK.DebuggerModel.CallFrame, this.update, this);
+        this._linkifier = new Components.Linkifier.Linkifier();
+        this.update();
+    }
+
+    static instance(opts: {
+        forceNew: boolean | null,
+    } = { forceNew: null }): DataBindingModelsPanelView {
+        const { forceNew } = opts;
+        if (!dataBindingModelsViewInstance || forceNew) {
+            dataBindingModelsViewInstance = new DataBindingModelsPanelView();
+        }
+
+        return dataBindingModelsViewInstance;
+    }
+
+    toolbarItems(): UI.Toolbar.ToolbarItem[] {
+        return this._toolbarItems;
+    }
+
+    focus(): void {
+        if (this.hasFocus()) {
+            return;
+        }
+        if (this._watchExpressions.length > 0) {
+            this._treeOutline.forceSelect();
+        }
+    }
+
+    hasExpressions(): boolean {
+        return Boolean(this._watchExpressionsSetting.get().length);
+    }
+
+    _saveExpressions(): void {
+        const toSave = [];
+        for (let i = 0; i < this._watchExpressions.length; i++) {
+            const expression = this._watchExpressions[i].expression();
+            if (expression) {
+                toSave.push(expression);
+            }
+        }
+
+        this._watchExpressionsSetting.set(toSave);
+    }
+
+    doUpdate(): Promise<void> {
+        this._linkifier.reset();
+        this.contentElement.removeChildren();
+        this._treeOutline.removeChildren();
+        this._watchExpressions.forEach((expression) => expression.clearWatchInterval());
+        this._watchExpressions = [];
+        this._emptyElement = (this.contentElement.createChild('div', 'gray-info-message') as HTMLElement);
+        this._emptyElement.textContent = i18nString(UIStrings.noWatchExpressions);
+        this._emptyElement.tabIndex = -1;
+
+        const watchExpressionStrings = this._watchExpressionsSetting.get();
+        if (watchExpressionStrings.length) {
+            this._emptyElement.classList.add('hidden');
+        }
+        for (let i = 0; i < watchExpressionStrings.length; ++i) {
+            const expression = watchExpressionStrings[i];
+            if (!expression) {
+                continue;
+            }
+
+            this._createWatchExpression(expression);
+        }
+        return Promise.resolve();
+    }
+
+    _createWatchExpression(expression: string | null): WatchExpression {
+        this.contentElement.appendChild(this._treeOutline.element);
+        const watchExpression = new WatchExpression(expression, this._expandController, this._linkifier, this._autoUpdateBindModelsSetting.get());
+        watchExpression.addEventListener(WatchExpression.Events.ExpressionUpdated, this._watchExpressionUpdated, this);
+        this._treeOutline.appendChild(watchExpression.treeElement());
+        this._watchExpressions.push(watchExpression);
+        return watchExpression;
+    }
+
+    _watchExpressionUpdated(event: Common.EventTarget.EventTargetEvent): void {
+        const watchExpression = (event.data as WatchExpression);
+        if (!watchExpression.expression()) {
+            Platform.ArrayUtilities.removeElement(this._watchExpressions, watchExpression);
+            this._treeOutline.removeChild(watchExpression.treeElement());
+            this._emptyElement.classList.toggle('hidden', Boolean(this._watchExpressions.length));
+            if (this._watchExpressions.length === 0) {
+                this._treeOutline.element.remove();
+            }
+        }
+
+        this._saveExpressions();
+    }
+
+    _contextMenu(event: MouseEvent): void {
+        const contextMenu = new UI.ContextMenu.ContextMenu(event);
+        this._populateContextMenu(contextMenu, event);
+        contextMenu.show();
+    }
+
+    _populateContextMenu(contextMenu: UI.ContextMenu.ContextMenu, event: MouseEvent): void {
+        let isEditing = false;
+        for (const watchExpression of this._watchExpressions) {
+            isEditing = isEditing || watchExpression.isEditing();
+        }
+
+        // if (!isEditing) {
+        //     contextMenu.debugSection().appendItem(
+        //         i18nString(UIStrings.addWatchExpression), this._addButtonClicked.bind(this));
+        // }
+
+        if (this._watchExpressions.length > 1) {
+            contextMenu.debugSection().appendItem(
+                i18nString(UIStrings.deleteAllWatchExpressions), this._deleteAllButtonClicked.bind(this));
+        }
+
+        const treeElement = this._treeOutline.treeElementFromEvent(event);
+        if (!treeElement) {
+            return;
+        }
+        const currentWatchExpression =
+            this._watchExpressions.find(watchExpression => treeElement.hasAncestorOrSelf(watchExpression.treeElement()));
+        if (currentWatchExpression) {
+            currentWatchExpression._populateContextMenu(contextMenu, event);
+        }
+    }
+
+    _deleteAllButtonClicked(): void {
+        this._watchExpressions = [];
+        this._saveExpressions();
+        this.update();
+    }
+
+    async _focusAndAddExpressionToWatch(expression: string): Promise<void> {
+        await UI.ViewManager.ViewManager.instance().showView('sources.watch');
+        this._createWatchExpression(expression);
+        this._saveExpressions();
+        this.update();
+    }
+
+    handleAction(_context: UI.Context.Context, _actionId: string): boolean {
+        return false
+        // const frame = UI.Context.Context.instance().flavor(UISourceCodeFrame);
+        // if (!frame) {
+        //   return false;
+        // }
+        // const text = frame.textEditor.text(frame.textEditor.selection());
+        // this._focusAndAddExpressionToWatch(text);
+        // return true;
+    }
+
+    appendApplicableItems(event: Event, contextMenu: UI.ContextMenu.ContextMenu, target: Object): void {
+        return;
+        // if (target instanceof ObjectUI.ObjectPropertiesSection.ObjectPropertyTreeElement && !target.property.synthetic) {
+        //     contextMenu.debugSection().appendItem(
+        //         i18nString(UIStrings.addPropertyPathToWatch), () => this._focusAndAddExpressionToWatch(target.path()));
+        // }
+
+        // const frame = UI.Context.Context.instance().flavor(UISourceCodeFrame);
+        // if (!frame || frame.textEditor.selection().isEmpty()) {
+        //     return;
+        // }
+
+        // contextMenu.debugSection().appendAction('sources.add-to-watch');
+    }
+}
+
+export class WatchExpression extends Common.ObjectWrapper.ObjectWrapper {
+    _treeElement!: UI.TreeOutline.TreeElement;
+    _nameElement!: Element;
+    _valueElement!: Element;
+    _expression: string | null;
+    _expandController: ObjectUI.ObjectPropertiesSection.ObjectPropertiesSectionsTreeExpandController;
+    _element: HTMLDivElement;
+    _editing: boolean;
+    _linkifier: Components.Linkifier.Linkifier;
+    _textPrompt?: ObjectUI.ObjectPropertiesSection.ObjectPropertyPrompt;
+    _result?: SDK.RemoteObject.RemoteObject | null;
+    _preventClickTimeout?: number;
+    _watchInterval: any;
+    constructor(
+        expression: string | null,
+        expandController: ObjectUI.ObjectPropertiesSection.ObjectPropertiesSectionsTreeExpandController,
+        linkifier: Components.Linkifier.Linkifier,
+        autoUpdateModels = false) {
+        super();
+
+        this._watchInterval = null;
+        this._expression = expression;
+        this._expandController = expandController;
+        this._element = document.createElement('div');
+        this._element.classList.add('watch-expression');
+        this._element.classList.add('monospace');
+        this._editing = false;
+        this._linkifier = linkifier;
+
+        this._createWatchExpression();
+        this.update();
+        if (autoUpdateModels) {
+            this._watchInterval = setInterval(() => this.update(), 2000)
+        }
+    }
+
+    clearWatchInterval() {
+        if (this._watchInterval) clearInterval(this._watchInterval);
+    }
+
+    treeElement(): UI.TreeOutline.TreeElement {
+        return this._treeElement;
+    }
+
+    expression(): string | null {
+        return this._expression;
+    }
+
+    update(): void {
+        const currentExecutionContext = UI.Context.Context.instance().flavor(SDK.RuntimeModel.ExecutionContext);
+        if (currentExecutionContext && this._expression) {
+            currentExecutionContext
+                .evaluate(
+                    {
+                        expression: this._expression,
+                        objectGroup: WatchExpression.watchObjectGroupId,
+                        includeCommandLineAPI: false,
+                        silent: true,
+                        returnByValue: false,
+                        generatePreview: false,
+                        allowUnsafeEvalBlockedByCSP: undefined,
+                        disableBreaks: undefined,
+                        replMode: undefined,
+                        throwOnSideEffect: undefined,
+                        timeout: undefined,
+                    },
+              /* userGesture */ false,
+              /* awaitPromise */ false)
+                .then(result => {
+                    if ('object' in result) {
+                        this._createWatchExpression(result.object, result.exceptionDetails);
+                    } else {
+                        this._createWatchExpression();
+                    }
+                });
+        } else {
+            this._createWatchExpression();
+        }
+    }
+
+    startEditing(): void {
+        this._editing = true;
+        this._treeElement.setDisableSelectFocus(true);
+        this._element.removeChildren();
+        const newDiv = this._element.createChild('div');
+        newDiv.textContent = this._nameElement.textContent;
+        this._textPrompt = new ObjectUI.ObjectPropertiesSection.ObjectPropertyPrompt();
+        this._textPrompt.renderAsBlock();
+        const proxyElement =
+            (this._textPrompt.attachAndStartEditing(newDiv, this._finishEditing.bind(this)) as HTMLElement);
+        this._treeElement.listItemElement.classList.add('watch-expression-editing');
+        this._treeElement.collapse();
+        proxyElement.classList.add('watch-expression-text-prompt-proxy');
+        proxyElement.addEventListener('keydown', this._promptKeyDown.bind(this), false);
+        const selection = this._element.getComponentSelection();
+        if (selection) {
+            selection.selectAllChildren(newDiv);
+        }
+    }
+
+    isEditing(): boolean {
+        return Boolean(this._editing);
+    }
+
+    _finishEditing(event: Event, canceled?: boolean): void {
+        if (event) {
+            event.consume(canceled);
+        }
+
+        this._editing = false;
+        this._treeElement.setDisableSelectFocus(false);
+        this._treeElement.listItemElement.classList.remove('watch-expression-editing');
+        if (this._textPrompt) {
+            this._textPrompt.detach();
+            const newExpression = canceled ? this._expression : this._textPrompt.text();
+            this._textPrompt = undefined;
+            this._element.removeChildren();
+            this._updateExpression(newExpression);
+        }
+    }
+
+    _dblClickOnWatchExpression(event: Event): void {
+        event.consume();
+        if (!this.isEditing()) {
+            this.startEditing();
+        }
+    }
+
+    _updateExpression(newExpression: string | null): void {
+        if (this._expression) {
+            this._expandController.stopWatchSectionsWithId(this._expression);
+        }
+        this._expression = newExpression;
+        this.update();
+        this.dispatchEventToListeners(WatchExpression.Events.ExpressionUpdated, this);
+    }
+
+    _deleteWatchExpression(event: Event): void {
+        event.consume(true);
+        this._updateExpression(null);
+    }
+
+    _createWatchExpression(result?: SDK.RemoteObject.RemoteObject, exceptionDetails?: Protocol.Runtime.ExceptionDetails):
+        void {
+        this._result = result || null;
+
+        this._element.removeChildren();
+        const oldTreeElement = this._treeElement;
+        this._createWatchExpressionTreeElement(result, exceptionDetails);
+        if (oldTreeElement && oldTreeElement.parent) {
+            const root = oldTreeElement.parent;
+            const index = root.indexOfChild(oldTreeElement);
+            root.removeChild(oldTreeElement);
+            root.insertChild(this._treeElement, index);
+        }
+        this._treeElement.select();
+    }
+
+    _createWatchExpressionHeader(
+        expressionValue?: SDK.RemoteObject.RemoteObject, exceptionDetails?: Protocol.Runtime.ExceptionDetails): Element {
+        const headerElement = this._element.createChild('div', 'watch-expression-header');
+        // const deleteButton = UI.Icon.Icon.create('smallicon-cross', 'watch-expression-delete-button');
+        // UI.Tooltip.Tooltip.install(deleteButton, i18nString(UIStrings.deleteWatchExpression));
+        // deleteButton.addEventListener('click', this._deleteWatchExpression.bind(this), false);
+
+        const titleElement = headerElement.createChild('div', 'watch-expression-title tree-element-title');
+        // titleElement.appendChild(deleteButton);
+        this._nameElement = ObjectUI.ObjectPropertiesSection.ObjectPropertiesSection.createNameElement(this._expression);
+        if (Boolean(exceptionDetails) || !expressionValue) {
+            this._valueElement = document.createElement('span');
+            this._valueElement.classList.add('watch-expression-error');
+            this._valueElement.classList.add('value');
+            titleElement.classList.add('dimmed');
+            this._valueElement.textContent = i18nString(UIStrings.notAvailable);
+            if (exceptionDetails !== undefined && exceptionDetails.exception !== undefined &&
+                exceptionDetails.exception.description !== undefined) {
+                UI.Tooltip.Tooltip.install(this._valueElement as HTMLElement, exceptionDetails.exception.description);
+            }
+        } else {
+            const propertyValue =
+                ObjectUI.ObjectPropertiesSection.ObjectPropertiesSection.createPropertyValueWithCustomSupport(
+                    expressionValue, Boolean(exceptionDetails), false /* showPreview */, titleElement, this._linkifier);
+            this._valueElement = propertyValue.element;
+        }
+        const separatorElement = document.createElement('span');
+        separatorElement.classList.add('watch-expressions-separator');
+        separatorElement.textContent = ': ';
+        titleElement.append(this._nameElement, separatorElement, this._valueElement);
+
+        return headerElement;
+    }
+
+    _createWatchExpressionTreeElement(
+        expressionValue?: SDK.RemoteObject.RemoteObject, exceptionDetails?: Protocol.Runtime.ExceptionDetails): void {
+        const headerElement = this._createWatchExpressionHeader(expressionValue, exceptionDetails);
+
+        if (!exceptionDetails && expressionValue && expressionValue.hasChildren && !expressionValue.customPreview()) {
+            headerElement.classList.add('watch-expression-object-header');
+            this._treeElement = new ObjectUI.ObjectPropertiesSection.RootElement(expressionValue, this._linkifier);
+            this._expandController.watchSection(
+                (this._expression as string), (this._treeElement as ObjectUI.ObjectPropertiesSection.RootElement));
+            this._treeElement.toggleOnClick = false;
+            this._treeElement.listItemElement.addEventListener('click', this._onSectionClick.bind(this), false);
+            this._treeElement.listItemElement.addEventListener('dblclick', this._dblClickOnWatchExpression.bind(this));
+        } else {
+            headerElement.addEventListener('dblclick', this._dblClickOnWatchExpression.bind(this));
+            this._treeElement = new UI.TreeOutline.TreeElement();
+        }
+        this._treeElement.title = this._element;
+        this._treeElement.listItemElement.classList.add('watch-expression-tree-item');
+        this._treeElement.listItemElement.addEventListener('keydown', event => {
+            if (event.key === 'Enter' && !this.isEditing()) {
+                this.startEditing();
+                event.consume(true);
+            }
+        });
+    }
+
+    _onSectionClick(event: Event): void {
+        event.consume(true);
+        const mouseEvent = (event as MouseEvent);
+        if (mouseEvent.detail === 1) {
+            this._preventClickTimeout = window.setTimeout(handleClick.bind(this), 333);
+        } else if (this._preventClickTimeout !== undefined) {
+            window.clearTimeout(this._preventClickTimeout);
+            this._preventClickTimeout = undefined;
+        }
+
+        function handleClick(this: WatchExpression): void {
+            if (!this._treeElement) {
+                return;
+            }
+
+            if (this._treeElement.expanded) {
+                this._treeElement.collapse();
+            } else if (!this._editing) {
+                this._treeElement.expand();
+            }
+        }
+    }
+
+    _promptKeyDown(event: KeyboardEvent): void {
+        if (event.key === 'Enter' || isEscKey(event)) {
+            this._finishEditing(event, isEscKey(event));
+        }
+    }
+
+    _populateContextMenu(contextMenu: UI.ContextMenu.ContextMenu, event: Event): void {
+        if (!this.isEditing()) {
+            contextMenu.editSection().appendItem(
+                i18nString(UIStrings.deleteWatchExpression), this._updateExpression.bind(this, null));
+        }
+
+        if (!this.isEditing() && this._result && (this._result.type === 'number' || this._result.type === 'string')) {
+            contextMenu.clipboardSection().appendItem(
+                i18nString(UIStrings.copyValue), this._copyValueButtonClicked.bind(this));
+        }
+
+        const target = UI.UIUtils.deepElementFromEvent(event);
+        if (target && this._valueElement.isSelfOrAncestor(target) && this._result) {
+            contextMenu.appendApplicableItems(this._result);
+        }
+    }
+
+    _copyValueButtonClicked(): void {
+        Host.InspectorFrontendHost.InspectorFrontendHostInstance.copyText(this._valueElement.textContent);
+    }
+
+    private static readonly watchObjectGroupId = 'watch-group';
+}
+
+export namespace WatchExpression {
+    // TODO(crbug.com/1167717): Make this a const enum again
+    // eslint-disable-next-line rulesdir/const_enum
+    export const Events = {
+        ExpressionUpdated: Symbol('ExpressionUpdated'),
+    };
+}

--- a/front_end/entrypoints/inspector_main/inspector_main-meta.ts
+++ b/front_end/entrypoints/inspector_main/inspector_main-meta.ts
@@ -27,7 +27,15 @@ const UIStrings = {
   * some Cohtml specific actions and settings.
   */
   cohtml: 'Cohtml',
-
+  /**
+  * @description Title of the Data binding models panel in the Command Menu. The panel shows preview and gives control over
+  * some bind models.
+  */
+  bindingModels: 'Data Binding Models',
+  /**
+  * @description Command prompt for the Data Binding Models panel in the Command menu.
+  */
+  showBindingModelsView: 'Show Data Binding Models View',
   /**
   * @description Command prompt for the Cohtml panel in the Command menu.
   */
@@ -154,6 +162,28 @@ UI.ViewManager.registerViewExtension({
 });
 
 // COHERENT_BEGIN
+UI.ViewManager.registerViewExtension({
+  location: UI.ViewManager.ViewLocationValues.DRAWER_VIEW,
+  id: 'cohtml-binding-models',
+  title: i18nLazyString(UIStrings.bindingModels),
+  commandPrompt: i18nLazyString(UIStrings.showBindingModelsView),
+  persistence: UI.ViewManager.ViewPersistence.CLOSEABLE,
+  order: 50,
+  hasToolbar: true,
+  async loadView() {
+    const InspectorMain = await loadInspectorMainModule();
+    return InspectorMain.DataBindingModelsPanelView.DataBindingModelsPanelView.instance();
+  },
+  tags: [
+  ],
+});
+
+Common.Settings.registerSettingExtension({
+  settingName: 'autoUpdateBindModels',
+  settingType: Common.Settings.SettingType.BOOLEAN,
+  defaultValue: false,
+});
+
 UI.ViewManager.registerViewExtension({
   location: UI.ViewManager.ViewLocationValues.DRAWER_VIEW,
   id: 'cohtml',

--- a/front_end/entrypoints/inspector_main/inspector_main.ts
+++ b/front_end/entrypoints/inspector_main/inspector_main.ts
@@ -5,6 +5,7 @@
 import './RenderingOptions.js';
 // COHERENT_BEGIN
 import './CohtmlPanel.js';
+import './DataBindingModelsPanel.js';
 // COHERENT_END
 import './InspectorMain.js';
 
@@ -12,6 +13,7 @@ import * as InspectorMain from './InspectorMain.js';
 import * as RenderingOptions from './RenderingOptions.js';
 // COHERENT_BEGIN
 import * as CohtmlPanelView from './CohtmlPanel.js';
+import * as DataBindingModelsPanelView from './DataBindingModelsPanel.js';
 // COHERENT_END
 
 export {
@@ -19,5 +21,6 @@ export {
   RenderingOptions,
   // COHERENT_BEGIN
   CohtmlPanelView,
+  DataBindingModelsPanelView,
   // COHERENT_END
 };

--- a/front_end/entrypoints/inspector_main/module.json
+++ b/front_end/entrypoints/inspector_main/module.json
@@ -1,6 +1,7 @@
 {
   "dependencies": [
     "ui/legacy/components/utils",
+    "ui/legacy/components/object_ui",
     "panels/mobile_throttling"
   ],
     "resources": [

--- a/front_end/panels/elements/BUILD.gn
+++ b/front_end/panels/elements/BUILD.gn
@@ -47,6 +47,7 @@ devtools_module("elements") {
     "StylePropertyHighlighter.ts",
     "StylePropertyTreeElement.ts",
     "StylesSidebarPane.ts",
+    "DataBindingSidebarPane.ts",
   ]
 
   deps = [

--- a/front_end/panels/elements/DataBindingSidebarPane.ts
+++ b/front_end/panels/elements/DataBindingSidebarPane.ts
@@ -1,0 +1,103 @@
+import * as UI from '../../ui/legacy/legacy.js';
+import * as SDK from '../../core/sdk/sdk.js';
+import * as Common from '../../core/common/common.js';
+import { ElementsSidebarPane } from './ElementsSidebarPane.js';
+import * as ElementsComponents from './components/components.js';
+
+let dataBindingPanelViewInstance: DataBindingSidebarPane;
+
+export class DataBindingSidebarPane extends ElementsSidebarPane {
+  private dataBindingsPanel: HTMLElement;
+  private selectedNode: HTMLElement;
+  private treeOutline: UI.TreeOutline.TreeOutline;
+  private bindingAttributes: SDK.DOMModel.Attribute[]
+
+  constructor() {
+    super(true);
+    this.bindingAttributes = [];
+
+    UI.Context.Context.instance().addFlavorChangeListener(SDK.DOMModel.DOMNode, this.doUpdate, this);
+    SDK.TargetManager.TargetManager.instance().addModelListener(
+      SDK.DOMModel.DOMModel, SDK.DOMModel.Events.DocumentUpdated, this._documentUpdatedEvent, this);
+
+    this.contentElement.classList.add('data-binding-panel-base');
+    this.dataBindingsPanel = this.contentElement.createChild('div', 'data-bindings-panel');
+    this.dataBindingsPanel.style.width = `100%`;
+    this.selectedNode = document.createElement('div');
+    // @ts-ignore
+    this.selectedNode.style = "display:flex; flex-direction:column;"
+    this.dataBindingsPanel.appendChild(this.selectedNode);
+
+    const treeElement = this.contentElement.createChild('div', 'bind-tree');
+    this.treeOutline = new UI.TreeOutline.TreeOutlineInShadow();
+    this.treeOutline.contentElement.classList.add('tree-outline');
+    this.registerRequiredCSS('ui/legacy/treeoutline.css');
+    this.registerRequiredCSS('ui/legacy/components/object_ui/objectValue.css');
+    this.registerRequiredCSS('ui/legacy/components/object_ui/objectPropertiesSection.css');
+    treeElement.appendChild(this.treeOutline.contentElement);
+
+    this.populateTree();
+    this.doUpdate();
+  }
+
+  populateTree() {
+    this.treeOutline.removeChildren();
+
+    this.bindingAttributes.forEach((attr) => {
+      const propTree = new ElementsComponents.DataBindingProperty.DataBindPropertyTreeElement(
+        {
+          attributeName: attr.name,
+          attributeValue: attr.value,
+          mutators: [{
+            evaluationNodes: [
+              { evaluatableExpression: '{{value}}', evaluatedValue: '1', type: 'string' },
+              { evaluatableExpression: '{{value1}}', evaluatedValue: 1, type: 'number' },
+              { evaluatableExpression: '{{value2}}', evaluatedValue: { test: 1, test2: { test3: ['1', undefined, false, 2, ['3'], { 4: '5', test: [{ 1: { 5: [3, { 6: 7 }] } }] }] } }, type: 'object' },
+              { evaluatableExpression: '{{value3}}', evaluatedValue: ["test", "test2"], type: 'array' },
+              { evaluatableExpression: '{{value4}}', evaluatedValue: undefined, type: 'undefined' },
+              { evaluatableExpression: '{{value4}}', evaluatedValue: true, type: 'boolean' },
+            ]
+          }]
+        }
+      );
+      propTree.setExpandable(true);
+      this.treeOutline.appendChild(propTree);
+    })
+  }
+
+  _documentUpdatedEvent(event: Common.EventTarget.EventTargetEvent<SDK.DOMModel.DOMModel>): void {
+    const domModel = event.data;
+  }
+
+  async doUpdate(): Promise<void> {
+    if (!this.node()) {
+      this.selectedNode.textContent = 'No node selected';
+      return;
+    }
+    const attr = this.node()?.attributes();
+    this.bindingAttributes = attr?.filter((attr) => attr.name.startsWith('data-bind') || attr.name.startsWith('data-meta-for')) || [];
+
+    this.selectedNode.innerHTML = `<div>Selected: ${this.node()?.nodeName()} with id ${this.node()?.backendNodeId()}</div>`;
+    this.populateTree();
+  }
+
+  modelAdded(domModel: SDK.DOMModel.DOMModel): void {
+    const parentModel = domModel.parentModel();
+    this.selectedNode.textContent = 'Model';
+  }
+
+  modelRemoved(domModel: SDK.DOMModel.DOMModel): void {
+
+  }
+
+  static instance(opts: {
+    forceNew: boolean | null,
+  } = { forceNew: null }): DataBindingSidebarPane {
+    const { forceNew } = opts;
+    if (!dataBindingPanelViewInstance || forceNew) {
+      dataBindingPanelViewInstance = new DataBindingSidebarPane();
+    }
+
+    return dataBindingPanelViewInstance;
+  }
+}

--- a/front_end/panels/elements/ElementsTreeElement.ts
+++ b/front_end/panels/elements/ElementsTreeElement.ts
@@ -194,6 +194,12 @@ const UIStrings = {
   * the overlay showing CSS scroll snapping for the current element.
   */
   disableScrollSnap: 'Disable scroll-snap overlay',
+  /* COHERENT_BEGIN */
+  /**
+  *@description A context menu item in the Elements Tree Element of the Elements panel
+  */
+  openInDataBindingTab: 'Open in Data-Binding Tab',
+  /* COHERENT_END */
 };
 const str_ = i18n.i18n.registerUIStrings('panels/elements/ElementsTreeElement.ts', UIStrings);
 const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
@@ -227,7 +233,13 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
   _searchHighlightsVisible?: boolean;
   selectionElement?: HTMLDivElement;
   _hintElement?: HTMLElement;
-
+  static createExclamationMark(tooltip: string): Element {
+    const exclamationElement = document.createElement('span', { is: 'dt-icon-label' }) as UI.UIUtils.DevToolsIconLabel;
+    exclamationElement.type = 'smallicon-warning';
+    exclamationElement.className = 'exclamation-mark';
+    UI.Tooltip.Tooltip.install(exclamationElement, tooltip);
+    return exclamationElement;
+  }
   constructor(node: SDK.DOMModel.DOMNode, isClosingTag?: boolean) {
     // The title will be updated in onattach.
     super();
@@ -623,6 +635,11 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
     }
     contextMenu.editSection().appendItem(
         i18nString(UIStrings.addAttribute), treeElement._addNewAttribute.bind(treeElement));
+    /* COHERENT_BEGIN */
+    contextMenu.editSection().appendItem(i18nString(UIStrings.openInDataBindingTab), () => {
+      UI.ViewManager.ViewManager.instance().showView('elements.data-binding-sidebar');
+    });
+    /* COHERENT_END */
 
     const target = (event.target as Element);
     const attribute = target.enclosingNodeOrSelfWithClass('webkit-html-attribute');
@@ -1288,6 +1305,9 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
       // fixme: make it clear that `this.title = x` is a setter with significant side effects
       this.title = highlightElement;
       this.updateDecorations();
+      if (this.node().attributes().find((attr) => attr.name.startsWith('data-bind'))) {
+        this.listItemElement.insertBefore(ElementsTreeElement.createExclamationMark('Data binding warning'), this.listItemElement.firstChild);
+      }
       this.listItemElement.insertBefore(this._gutterContainer, this.listItemElement.firstChild);
       if (!this._isClosingTag && this._adornerContainer) {
         this.listItemElement.appendChild(this._adornerContainer);
@@ -1441,7 +1461,7 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
     let highlightCount = 0;
     let additionalHighlightOffset = 0;
 
-    function setValueWithEntities(this: ElementsTreeElement, element: Element, value: string): void {
+    function setValueWithEntities(this: ElementsTreeElement, element: Element, value: string, dataBindAttr = false): void {
       const result = this._convertWhitespaceToEntities(value);
       highlightCount = result.entityRanges.length;
       value = result.text.replace(closingPunctuationRegex, (match, replaceOffset) => {
@@ -1457,7 +1477,40 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
         result.entityRanges[highlightIndex].offset += additionalHighlightOffset;
         ++highlightIndex;
       }
-      element.setTextContentTruncatedIfNeeded(value);
+      /* COHERENT_BEGIN */
+      if (!dataBindAttr) {
+        element.setTextContentTruncatedIfNeeded(value);
+      } else {
+        const regex = /\{\{([^}]|}(?!}))*\}\}/g;
+        let lastIndex = 0;
+        let match: RegExpExecArray | null;
+        const plainValue = value.replace(/[\u200B-\u200D\uFEFF]/g, '');
+        while ((match = regex.exec(plainValue)) !== null) {
+          // Text before the expression
+          if (match.index > lastIndex) {
+            const textSpan = document.createElement('span');
+            textSpan.textContent = plainValue.slice(lastIndex, match.index);
+            element.appendChild(textSpan);
+          }
+
+          // Expression span
+          const exprSpan = document.createElement('span');
+          exprSpan.classList.add('data-bind-expression');
+          exprSpan.textContent = match[0];
+          element.appendChild(exprSpan);
+
+          lastIndex = match.index + match[0].length;
+        }
+
+        // Remaining text
+        if (lastIndex < plainValue.length) {
+          const remainingSpan = document.createElement('span');
+          remainingSpan.textContent = plainValue.slice(lastIndex);
+          element.appendChild(remainingSpan);
+        }
+        // value.matchAll()
+      }
+      /* COHERENT_END */
       UI.UIUtils.highlightRangesWithStyleClass(element, result.entityRanges, 'webkit-html-entity-value');
     }
 
@@ -1511,7 +1564,9 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
     } else if (nodeName === 'image' && (name === 'xlink:href' || name === 'href')) {
       attrValueElement.appendChild(linkifySrcset.call(this, value));
     } else {
-      setValueWithEntities.call(this, attrValueElement, value);
+      /* COHERENT_BEGIN */
+      setValueWithEntities.call(this, attrValueElement, value, attrNameElement.textContent.startsWith('data-bind') || attrNameElement.textContent.startsWith('data-meta-for-element'));
+      /* COHERENT_END */
     }
 
     if (hasText) {

--- a/front_end/panels/elements/ElementsTreeOutline.ts
+++ b/front_end/panels/elements/ElementsTreeOutline.ts
@@ -38,6 +38,9 @@ import * as Common from '../../core/common/common.js';
 import * as i18n from '../../core/i18n/i18n.js';
 import * as SDK from '../../core/sdk/sdk.js';
 import * as UI from '../../ui/legacy/legacy.js';
+/* COHERENT_BEGIN */
+import { PopoverRequest } from '../../ui/legacy/PopoverHelper.js';
+/* COHERENT_END */
 
 import {linkifyDeferredNodeReference} from './DOMLinkifier.js';
 import {ElementsPanel} from './ElementsPanel.js';
@@ -97,6 +100,9 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
   _treeElementBeingDragged?: ElementsTreeElement;
   _dragOverTreeElement?: ElementsTreeElement;
   _updateModifiedNodesTimeout?: number;
+  /* COHERENT_BEGIN */
+  _popoverHelper: UI.PopoverHelper.PopoverHelper;
+  /* COHERENT_END */
 
   constructor(omitRootDOMNode?: boolean, selectEnabled?: boolean, hideGutter?: boolean) {
     super();
@@ -105,7 +111,13 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     this._shadowRoot = UI.Utils.createShadowRootWithCoreStyles(
         shadowContainer, {cssFile: 'panels/elements/elementsTreeOutline.css', delegatesFocus: undefined});
     const outlineDisclosureElement = this._shadowRoot.createChild('div', 'elements-disclosure');
-
+    /* COHERENT_BEGIN */
+    this._popoverHelper = new UI.PopoverHelper.PopoverHelper(
+      this.element,
+      this._requestPopover.bind(this),
+    );
+    this._popoverHelper.setTimeout(0, 0);
+    /* COHERENT_END */
     this._element = this.element;
     this._element.classList.add('elements-tree-outline', 'source-code');
     if (hideGutter) {
@@ -174,7 +186,30 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
   static forDOMModel(domModel: SDK.DOMModel.DOMModel): ElementsTreeOutline|null {
     return elementsTreeOutlineByDOMModel.get(domModel) || null;
   }
+  /* COHERENT_BEGIN */
+  _requestPopover(event: MouseEvent): PopoverRequest | null {
+    const target = event.target as HTMLElement;
+    if (!target?.classList.contains('data-bind-expression')) {
+      return null;
+    }
 
+    return {
+      box: target.boxInWindow(),
+      show: (popover: UI.GlassPane.GlassPane) => {
+        const container = document.createElement('div');
+        container.classList.add('bind-expression-popover');
+
+        const rawExpr = target.textContent || '';
+        const expr = rawExpr.replace(/^\{\{|\}\}$/g, '');
+
+        container.textContent = `Evaluated: ${expr}`;
+
+        popover.contentElement.appendChild(container);
+        return Promise.resolve(true);
+      }
+    };
+  }
+  /* COHERENT_END */
   _onShowHTMLCommentsChange(): void {
     const selectedNode = this.selectedDOMNode();
     if (selectedNode && selectedNode.nodeType() === Node.COMMENT_NODE && !this._showHTMLCommentsSetting.get()) {

--- a/front_end/panels/elements/components/BUILD.gn
+++ b/front_end/panels/elements/components/BUILD.gn
@@ -18,6 +18,7 @@ generate_css("css_files") {
     "nodeText.css",
     "queryContainer.css",
     "stylePropertyEditor.css",
+    "dataBindingProperty.css",
   ]
 }
 
@@ -39,6 +40,7 @@ devtools_module("components") {
     "NodeText.ts",
     "QueryContainer.ts",
     "StylePropertyEditor.ts",
+    "DataBindingProperty.ts",
   ]
 
   deps = [
@@ -52,6 +54,7 @@ devtools_module("components") {
     "../../../ui/components/render_coordinator:bundle",
     "../../../ui/components/survey_link:bundle",
     "../../../ui/components/tree_outline:bundle",
+    "../../../ui/legacy/components/object_ui:bundle",
     "../../../ui/legacy:bundle",
     "../../../ui/lit-html:bundle",
   ]

--- a/front_end/panels/elements/components/DataBindingProperty.ts
+++ b/front_end/panels/elements/components/DataBindingProperty.ts
@@ -1,0 +1,155 @@
+import * as UI from '../../../ui/legacy/legacy.js';
+import * as ObjectUI from '../../../ui/legacy/components/object_ui/object_ui.js';
+import * as SDK from '../../../core/sdk/sdk.js';
+import * as Protocol from '../../../generated/protocol.js';
+
+import dataBindingProperty from './dataBindingProperty.css.js';
+
+interface DataBindNode {
+  evaluatableExpression: string
+  evaluatedValue: string | number | object | any
+  type: 'string' | 'number' | 'object' | 'array' | 'undefined' | 'boolean'
+  syncStatus?: boolean
+  evaluationError?: string
+}
+
+interface MutatorData {
+  parsingError?: string
+  compilationError?: string
+  evaluationNodes: DataBindNode[]
+}
+
+interface DataBindAttributeData {
+  attributeName: string, attributeValue: string, mutators: MutatorData[]
+}
+
+export class DataBindNodeTreeElement extends UI.TreeOutline.TreeElement {
+  private readonly node: DataBindNode
+  constructor(node: DataBindNode) {
+    super();
+    this.node = node;
+    this.listItemElement.classList.add('monospace');
+    this.setDisableSelectFocus(true)
+  }
+
+  onattach(): void {
+    this.update();
+  }
+
+  appendEvaluatableExpressionElement(): void {
+    switch (this.node.type) {
+      case 'string':
+      case 'number':
+      case 'undefined':
+      case 'boolean':
+        {
+          const nameElement = document.createElement('span');
+          nameElement.textContent = this.node.evaluatableExpression || null;
+          nameElement.classList.add('object-value-string');
+          this.listItemElement.appendChild(nameElement);
+          this.listItemElement.createChild('span', 'separator').textContent = ':\xA0';
+          const valueElement = document.createElement('span');
+          valueElement.textContent = this.node.type === 'string' ? `"${this.node.evaluatedValue}"` : this.node.evaluatedValue;
+          valueElement.classList.add('object-value-' + this.node.type);
+          this.listItemElement.appendChild(valueElement);
+          break;
+        }
+      case 'array':
+      case 'object': {
+        const object = SDK.RemoteObject.RemoteObject.fromLocalObject(this.node.evaluatedValue);
+        console.log(object)
+
+        const title = document.createElement('div');
+        title.classList.add('name-and-value')
+        const nameElement = document.createElement('span');
+        nameElement.textContent = this.node.evaluatableExpression || null;
+        nameElement.classList.add('object-value-string');
+        title.appendChild(nameElement);
+        title.createChild('span', 'separator').textContent = ':\xA0';
+        const valueElement = document.createElement('span');
+        valueElement.textContent = JSON.stringify(this.node.evaluatedValue);
+        valueElement.classList.add('object-value-object');
+        title.appendChild(valueElement);
+
+        const tree = new ObjectUI.ObjectPropertiesSection.ObjectPropertiesSection(object, title, void 0, false);
+        tree._renderSelection = false;
+        //@ts-ignore
+        // this.appendChild(tree);
+        this.listItemElement.appendChild(tree.element);
+        break;
+      }
+    }
+
+  }
+
+  private update(): void {
+    this.listItemElement.removeChildren();
+
+    this.appendEvaluatableExpressionElement();
+  }
+}
+
+export class DataBindTreeElement extends UI.TreeOutline.TreeElement {
+  constructor() {
+    super('');
+    this.setExpandable(true);
+    this.setDisableSelectFocus(true)
+  }
+
+  static createExclamationMark(tooltip: string): Element {
+    const exclamationElement = document.createElement('span', { is: 'dt-icon-label' }) as UI.UIUtils.DevToolsIconLabel;
+    exclamationElement.type = 'smallicon-warning';
+    UI.Tooltip.Tooltip.install(exclamationElement, tooltip);
+    return exclamationElement;
+  }
+
+  appendNameElement(name: string): void {
+    const nameElement = document.createElement('span');
+    nameElement.textContent = name;
+    nameElement.classList.add('name');
+    this.listItemElement.appendChild(nameElement);
+    this.listItemElement.insertBefore(DataBindTreeElement.createExclamationMark('Data binding warning'), this.listItemElement.firstChild);
+
+  }
+
+  appendValueElement(value: string): void {
+    const nameElement = document.createElement('span');
+    nameElement.textContent = value;
+    nameElement.classList.add('object-value-string');
+    this.listItemElement.appendChild(nameElement);
+  }
+}
+
+export class DataBindPropertyTreeElement extends DataBindTreeElement {
+  private readonly property: DataBindAttributeData;
+  toggleOnClick: boolean;
+  constructor(
+    property: DataBindAttributeData) {
+    super();
+
+    this.property = property;
+    this.toggleOnClick = true;
+
+    this.listItemElement.classList.add('monospace');
+  }
+
+  onattach(): void {
+    this.update();
+  }
+
+  private update(): void {
+    this.listItemElement.removeChildren();
+
+    this.appendNameElement(this.property.attributeName);
+
+    this.listItemElement.createChild('span', 'separator').textContent = ':\xA0';
+
+    this.appendValueElement(this.property.attributeValue);
+    this.property.mutators.forEach((mutator) => {
+      mutator.evaluationNodes.forEach((evalNode) => {
+        const node = new DataBindNodeTreeElement(evalNode);
+        this.appendChild(node);
+      })
+    })
+  }
+}

--- a/front_end/panels/elements/components/components.ts
+++ b/front_end/panels/elements/components/components.ts
@@ -18,6 +18,9 @@ import * as LayoutPaneUtils from './LayoutPaneUtils.js';
 import * as NodeText from './NodeText.js';
 import * as QueryContainer from './QueryContainer.js';
 import * as StylePropertyEditor from './StylePropertyEditor.js';
+/* COHERENT_BEGIN */
+import * as DataBindingProperty from './DataBindingProperty.js';
+/* COHERENT_END */
 
 export {
   AccessibilityTreeNode,
@@ -36,4 +39,7 @@ export {
   NodeText,
   QueryContainer,
   StylePropertyEditor,
+  /* COHERENT_BEGIN */
+  DataBindingProperty,
+  /* COHERENT_END */
 };

--- a/front_end/panels/elements/elements-legacy.ts
+++ b/front_end/panels/elements/elements-legacy.ts
@@ -100,6 +100,9 @@ Elements.StylePropertyTreeElement = ElementsModule.StylePropertyTreeElement.Styl
 Elements.StylesSidebarPane = ElementsModule.StylesSidebarPane.StylesSidebarPane;
 
 /** @constructor */
+Elements.DataBindingSidebarPane = ElementsModule.DataBindingSidebarPane.DataBindingSidebarPane;
+
+/** @constructor */
 Elements.StylesSidebarPane.CSSPropertyPrompt = ElementsModule.StylesSidebarPane.CSSPropertyPrompt;
 
 /** @constructor */

--- a/front_end/panels/elements/elements-meta.ts
+++ b/front_end/panels/elements/elements-meta.ts
@@ -133,10 +133,13 @@ const UIStrings = {
    * the shadow DOM nodes of HTML elements that are built into the browser (e.g. the <input> element).
    */
   showUserAgentShadowDOM: 'Show user agent shadow `DOM`',
+  /* COHERENT_BEGIN */
+  dataBinding: 'Data Binding',
+  /* COHERENT_END */
 };
 const str_ = i18n.i18n.registerUIStrings('panels/elements/elements-meta.ts', UIStrings);
 const i18nLazyString = i18n.i18n.getLazilyComputedLocalizedString.bind(undefined, str_);
-let loadedElementsModule: (typeof Elements|undefined);
+let loadedElementsModule: (typeof Elements | undefined);
 
 async function loadElementsModule(): Promise<typeof Elements> {
   if (!loadedElementsModule) {
@@ -207,6 +210,21 @@ UI.ViewManager.registerViewExtension({
     return Elements.NodeStackTraceWidget.NodeStackTraceWidget.instance();
   },
 });
+
+/* COHERENT_BEGIN */
+UI.ViewManager.registerViewExtension({
+  location: UI.ViewManager.ViewLocationValues.ELEMENTS_SIDEBAR,
+  id: 'elements.data-binding-sidebar',
+  title: i18nLazyString(UIStrings.dataBinding),
+  commandPrompt: i18nLazyString(UIStrings.dataBinding),
+  persistence: UI.ViewManager.ViewPersistence.PERMANENT,
+  order: 4,
+  async loadView() {
+    const Elements = await loadElementsModule();
+    return Elements.DataBindingSidebarPane.DataBindingSidebarPane.instance();
+  },
+});
+/* COHERENT_END */
 
 UI.ViewManager.registerViewExtension({
   location: UI.ViewManager.ViewLocationValues.ELEMENTS_SIDEBAR,

--- a/front_end/panels/elements/elements.ts
+++ b/front_end/panels/elements/elements.ts
@@ -18,6 +18,9 @@ import './PropertiesWidget.js';
 import './NodeStackTraceWidget.js';
 import './StylePropertyHighlighter.js';
 import './StylesSidebarPane.js';
+/* COHERENT_BEGIN */
+import './DataBindingSidebarPane.js';
+/* COHERENT_END */
 import './StylePropertyTreeElement.js';
 import './ComputedStyleWidget.js';
 import './ElementsPanel.js';
@@ -49,6 +52,9 @@ import * as StyleEditorWidget from './StyleEditorWidget.js';
 import * as StylePropertyHighlighter from './StylePropertyHighlighter.js';
 import * as StylePropertyTreeElement from './StylePropertyTreeElement.js';
 import * as StylesSidebarPane from './StylesSidebarPane.js';
+/* COHERENT_BEGIN */
+import * as DataBindingSidebarPane from './DataBindingSidebarPane.js';
+/* COHERENT_END */
 
 export {
   ClassesPaneWidget,
@@ -75,4 +81,7 @@ export {
   StylePropertyHighlighter,
   StylePropertyTreeElement,
   StylesSidebarPane,
+  /* COHERENT_BEGIN */
+  DataBindingSidebarPane,
+  /* COHERENT_END */
 };

--- a/front_end/panels/elements/elementsTreeOutline.css
+++ b/front_end/panels/elements/elementsTreeOutline.css
@@ -359,3 +359,10 @@ li.hovered:not(.always-parent) + ol.children:not(.shadow-root) {
     forced-color-adjust: none;
   }
 }
+
+/* COHERENT_BEGIN */
+.bind-expression-popover {
+  width: 300px;
+  height: 100px;
+}
+/* COHERENT_END */

--- a/front_end/ui/legacy/components/object_ui/BUILD.gn
+++ b/front_end/ui/legacy/components/object_ui/BUILD.gn
@@ -63,6 +63,7 @@ devtools_entrypoint("bundle") {
     "../../../../panels/profiler/*",
     "../../../../panels/sources/*",
     "../source_frame/*",
+    "../../../../entrypoints/inspector_main/*",
   ]
 
   visibility += devtools_ui_legacy_visibility

--- a/front_end/ui/legacy/inspectorSyntaxHighlight.css
+++ b/front_end/ui/legacy/inspectorSyntaxHighlight.css
@@ -346,3 +346,10 @@
     color: HighlightText;
   }
 }
+
+/* COHERENT_BEGIN */
+.data-bind-expression:hover {
+  color: HighlightText;
+  background-color: Highlight;
+}
+/* COHERENT_END */


### PR DESCRIPTION
This branch sets up the Data Binding tab, Data Binding Models, and syntax highlighting in the Inspector.

The following files are initial implementations and currently display mocked data. They will be further developed and refined in upcoming PRs:

* DataBindingModelsPanel.ts
* DataBindingSidebarPane.ts
* ElementsTreeElement.ts
* ElementsTreeOutline.ts
* DataBindingProperty.ts

To run the Inspector, please follow the setup guide here: https://github.com/CoherentLabs/cohtml/tree/develop/Tools/InspectorResources#1-setting-up-depot-tools

If you have any questions, feel free to reach out to me.