### PR TITLE
Added data-bind-attribute tips when are hovered in the elements tab

### DIFF
--- a/front_end/panels/elements/DataBindingSidebarPane.ts
+++ b/front_end/panels/elements/DataBindingSidebarPane.ts
@@ -15,7 +15,9 @@ const UIStrings = {
   noAttributes: 'No data bind attributes for the selected node',
   fetchDataWarning: 'Unable to fetch data for the selected node',
   expandAllExpressions: 'Expand all the expressions in the tab',
-  collapseAllExpressions: 'Collapse all the expressions in the tab'
+  collapseAllExpressions: 'Collapse all the expressions in the tab',
+  highlightAttibutesSetting: 'Hover bind attributes',
+  highlightAttibutesSettingDescription: 'Show an informative popover when data-bind attribute is hovered in the elements tab and the option is enabled.'
 };
 const str_ = i18n.i18n.registerUIStrings('panels/elements/DataBindingSidebarPane.ts', UIStrings);
 const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
@@ -30,7 +32,6 @@ export class DataBindingSidebarPane extends ElementsSidebarPane {
   private readonly fetchDataWarning: Element;
   private activeWarningMessage: Element | null = null;
   private filterRegex: RegExp | null = null;
-  private toolbar: UI.Toolbar.Toolbar | null = null;
 
   constructor() {
     super(true);
@@ -70,23 +71,33 @@ export class DataBindingSidebarPane extends ElementsSidebarPane {
   }
 
   createToolbar() {
-    this.toolbar = new UI.Toolbar.Toolbar('', this.contentElement);
-    this.toolbar._shadowRoot.adoptedStyleSheets = [...this.toolbar._shadowRoot.adoptedStyleSheets, dataBindingPanelToolbarStyles];
+    const toolbar = new UI.Toolbar.Toolbar('', this.contentElement);
+    toolbar._shadowRoot.adoptedStyleSheets = [...toolbar._shadowRoot.adoptedStyleSheets, dataBindingPanelToolbarStyles];
 
     const filterInput = this.createFilterElement(this.onFilterChange.bind(this));
-    this.toolbar?.appendToolbarItem(filterInput);
+    toolbar?.appendToolbarItem(filterInput);
 
     const expandIcon = this.createArrowIcon('expand-tree-icon');
     const expandAllBtn =
       new UI.Toolbar.ToolbarButton(i18nString(UIStrings.expandAllExpressions), expandIcon);
     expandAllBtn.addEventListener(UI.Toolbar.ToolbarButton.Events.Click, this.expandTree.bind(this), this);
-    this.toolbar?.appendToolbarItem(expandAllBtn);
+    toolbar?.appendToolbarItem(expandAllBtn);
 
     const collapseIcon = this.createArrowIcon('collapse-tree-icon');
     const collapseAllBtn =
       new UI.Toolbar.ToolbarButton(i18nString(UIStrings.collapseAllExpressions), collapseIcon);
     collapseAllBtn.addEventListener(UI.Toolbar.ToolbarButton.Events.Click, this.collapseTree.bind(this), this);
-    this.toolbar?.appendToolbarItem(collapseAllBtn);
+    toolbar?.appendToolbarItem(collapseAllBtn);
+
+    const secondToolbar = new UI.Toolbar.Toolbar('second', this.contentElement);
+    secondToolbar._shadowRoot.adoptedStyleSheets = [...secondToolbar._shadowRoot.adoptedStyleSheets, dataBindingPanelToolbarStyles];
+
+    const highlightBindingAttributesSetting =
+      Common.Settings.Settings.instance().moduleSetting('highlightBindingAttributes');
+    highlightBindingAttributesSetting.setTitle(i18nString(UIStrings.highlightAttibutesSetting))
+    const highlightBindingAttributesBtn =
+      new UI.Toolbar.ToolbarSettingCheckbox(highlightBindingAttributesSetting, i18nString(UIStrings.highlightAttibutesSettingDescription));
+    secondToolbar?.appendToolbarItem(highlightBindingAttributesBtn);
   }
 
   onFilterChange(value: RegExp | null) {
@@ -159,15 +170,13 @@ export class DataBindingSidebarPane extends ElementsSidebarPane {
     return exclamationElement;
   }
 
-  populateTree(data: Protocol.DOM.DataBindAttributeData[], domModel: SDK.DOMModel.DOMModel | undefined) {
+  populateTree(data: Protocol.DOM.DataBindAttributeData[]) {
     this.hideMessages();
     this.treeElement.classList.toggle('hidden', false);
-    const runtimeModel = domModel?.runtimeModel();
-    const executionContext = runtimeModel?.executionContexts()[0];
 
     for (let i = 0; i < data.length; i++) {
       if (!this.bindingAttributes[i]) {
-        const attrTree = new ElementsComponents.DataBindingProperty.DataBindAttributeTreeElement(data[i], executionContext);
+        const attrTree = new ElementsComponents.DataBindingProperty.DataBindAttributeTreeElement(data[i]);
         attrTree.setExpandable(true);
         attrTree.selectable = false;
         attrTree.expand();
@@ -222,7 +231,7 @@ export class DataBindingSidebarPane extends ElementsSidebarPane {
     const attributes = data?.dataBindAttributes || [];
     if (!attributes.length) return this.showMessage(this.noAttributesInfo);
 
-    this.populateTree(attributes, domModel);
+    this.populateTree(attributes);
     if (this.filterRegex) this.onFilterChange(this.filterRegex);
   }
 

--- a/front_end/panels/elements/DataBindingSidebarPane.ts
+++ b/front_end/panels/elements/DataBindingSidebarPane.ts
@@ -16,8 +16,8 @@ const UIStrings = {
   fetchDataWarning: 'Unable to fetch data for the selected node',
   expandAllExpressions: 'Expand all the expressions in the tab',
   collapseAllExpressions: 'Collapse all the expressions in the tab',
-  highlightAttibutesSetting: 'Hover bind attributes',
-  highlightAttibutesSettingDescription: 'Show an informative popover when data-bind attribute is hovered in the elements tab and the option is enabled.'
+  highlightAttributesSetting: 'Hover bind attributes',
+  highlightAttributesSettingDescription: 'Show an informative popover when data-bind attribute is hovered in the elements tab and the option is enabled.'
 };
 const str_ = i18n.i18n.registerUIStrings('panels/elements/DataBindingSidebarPane.ts', UIStrings);
 const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
@@ -94,9 +94,9 @@ export class DataBindingSidebarPane extends ElementsSidebarPane {
 
     const highlightBindingAttributesSetting =
       Common.Settings.Settings.instance().moduleSetting('highlightBindingAttributes');
-    highlightBindingAttributesSetting.setTitle(i18nString(UIStrings.highlightAttibutesSetting))
+    highlightBindingAttributesSetting.setTitle(i18nString(UIStrings.highlightAttributesSetting));
     const highlightBindingAttributesBtn =
-      new UI.Toolbar.ToolbarSettingCheckbox(highlightBindingAttributesSetting, i18nString(UIStrings.highlightAttibutesSettingDescription));
+      new UI.Toolbar.ToolbarSettingCheckbox(highlightBindingAttributesSetting, i18nString(UIStrings.highlightAttributesSettingDescription));
     secondToolbar?.appendToolbarItem(highlightBindingAttributesBtn);
   }
 

--- a/front_end/panels/elements/ElementsTreeElement.ts
+++ b/front_end/panels/elements/ElementsTreeElement.ts
@@ -39,6 +39,7 @@ import * as Host from '../../core/host/host.js';
 import * as i18n from '../../core/i18n/i18n.js';
 import * as Platform from '../../core/platform/platform.js';
 import * as SDK from '../../core/sdk/sdk.js';
+import * as Protocol from '../../generated/protocol.js';
 import * as TextUtils from '../../models/text_utils/text_utils.js';
 import * as Adorners from '../../ui/components/adorners/adorners.js';
 import * as TextEditor from '../../ui/legacy/components/text_editor/text_editor.js';
@@ -233,13 +234,19 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
   _searchHighlightsVisible?: boolean;
   selectionElement?: HTMLDivElement;
   _hintElement?: HTMLElement;
-  static createExclamationMark(tooltip: string): Element {
-    const exclamationElement = document.createElement('span', { is: 'dt-icon-label' }) as UI.UIUtils.DevToolsIconLabel;
-    exclamationElement.type = 'smallicon-warning';
-    exclamationElement.className = 'exclamation-mark';
-    UI.Tooltip.Tooltip.install(exclamationElement, tooltip);
-    return exclamationElement;
+  /* COHERENT_BEGIN */
+  _gettingBindingData: boolean;
+  _dataBindingData: Protocol.DOM.DataBindAttributeData[] | null;
+  /* COHERENT_END */
+  
+  static createErrorMark(tooltip: string, additionalClasses:string = ''): Element {
+    const errorElement = document.createElement('span', { is: 'dt-icon-label' }) as UI.UIUtils.DevToolsIconLabel;
+    errorElement.type = 'smallicon-error';
+    errorElement.className = 'error-mark' + ' ' + additionalClasses;
+    UI.Tooltip.Tooltip.install(errorElement, tooltip);
+    return errorElement;
   }
+
   constructor(node: SDK.DOMModel.DOMNode, isClosingTag?: boolean) {
     // The title will be updated in onattach.
     super();
@@ -285,6 +292,11 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
     }
 
     this.expandAllButtonElement = null;
+
+    /* COHERENT_BEGIN */
+    this._gettingBindingData = false;
+    this._dataBindingData = null;
+    /* COHERENT_END */
   }
 
   static animateOnDOMUpdate(treeElement: ElementsTreeElement): void {
@@ -1305,9 +1317,6 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
       // fixme: make it clear that `this.title = x` is a setter with significant side effects
       this.title = highlightElement;
       this.updateDecorations();
-      if (this.node().attributes().find((attr) => attr.name.startsWith('data-bind'))) {
-        this.listItemElement.insertBefore(ElementsTreeElement.createExclamationMark('Data binding warning'), this.listItemElement.firstChild);
-      }
       this.listItemElement.insertBefore(this._gutterContainer, this.listItemElement.firstChild);
       if (!this._isClosingTag && this._adornerContainer) {
         this.listItemElement.appendChild(this._adornerContainer);
@@ -1461,7 +1470,7 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
     let highlightCount = 0;
     let additionalHighlightOffset = 0;
 
-    function setValueWithEntities(this: ElementsTreeElement, element: Element, value: string, dataBindAttr = false): void {
+    function setValueWithEntities(this: ElementsTreeElement, element: Element, value: string): void {
       const result = this._convertWhitespaceToEntities(value);
       highlightCount = result.entityRanges.length;
       value = result.text.replace(closingPunctuationRegex, (match, replaceOffset) => {
@@ -1477,40 +1486,8 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
         result.entityRanges[highlightIndex].offset += additionalHighlightOffset;
         ++highlightIndex;
       }
-      /* COHERENT_BEGIN */
-      if (!dataBindAttr) {
-        element.setTextContentTruncatedIfNeeded(value);
-      } else {
-        const regex = /\{\{([^}]|}(?!}))*\}\}/g;
-        let lastIndex = 0;
-        let match: RegExpExecArray | null;
-        const plainValue = value.replace(/[\u200B-\u200D\uFEFF]/g, '');
-        while ((match = regex.exec(plainValue)) !== null) {
-          // Text before the expression
-          if (match.index > lastIndex) {
-            const textSpan = document.createElement('span');
-            textSpan.textContent = plainValue.slice(lastIndex, match.index);
-            element.appendChild(textSpan);
-          }
+      element.setTextContentTruncatedIfNeeded(value);
 
-          // Expression span
-          const exprSpan = document.createElement('span');
-          exprSpan.classList.add('data-bind-expression');
-          exprSpan.textContent = match[0];
-          element.appendChild(exprSpan);
-
-          lastIndex = match.index + match[0].length;
-        }
-
-        // Remaining text
-        if (lastIndex < plainValue.length) {
-          const remainingSpan = document.createElement('span');
-          remainingSpan.textContent = plainValue.slice(lastIndex);
-          element.appendChild(remainingSpan);
-        }
-        // value.matchAll()
-      }
-      /* COHERENT_END */
       UI.UIUtils.highlightRangesWithStyleClass(element, result.entityRanges, 'webkit-html-entity-value');
     }
 
@@ -1518,6 +1495,19 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
     const attrSpanElement = (parentElement.createChild('span', 'webkit-html-attribute') as HTMLElement);
     const attrNameElement = attrSpanElement.createChild('span', 'webkit-html-attribute-name');
     attrNameElement.textContent = name;
+
+    /* COHERENT_BEGIN */
+    if (attrNameElement.textContent.startsWith('data-')) {
+      attrSpanElement.insertBefore(ElementsTreeElement.createErrorMark(`Errors generated while parsing the "${name}" attribute.`, 'data-attr-error hidden'), attrNameElement);
+      attrSpanElement.classList.add('data-bind-expression');
+      //@ts-ignore
+      attrSpanElement.domModel = this._node.domModel();
+      //@ts-ignore
+      attrSpanElement.attrName = name;
+      //@ts-ignore
+      attrSpanElement.nodeId = this._node.id;
+    }
+    /* COHERENT_END */
 
     if (hasText) {
       UI.UIUtils.createTextChild(attrSpanElement, '=\u200B"');
@@ -1564,9 +1554,7 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
     } else if (nodeName === 'image' && (name === 'xlink:href' || name === 'href')) {
       attrValueElement.appendChild(linkifySrcset.call(this, value));
     } else {
-      /* COHERENT_BEGIN */
-      setValueWithEntities.call(this, attrValueElement, value, attrNameElement.textContent.startsWith('data-bind') || attrNameElement.textContent.startsWith('data-meta-for-element'));
-      /* COHERENT_END */
+      setValueWithEntities.call(this, attrValueElement, value);
     }
 
     if (hasText) {
@@ -1648,10 +1636,31 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
     if (!isClosingTag) {
       if (node.hasAttributes()) {
         const attributes = node.attributes();
+        /* COHERENT_BEGIN */
+        const attrElements = [] as { element: HTMLElement, name: string }[];
+        /* COHERENT_END */
         for (let i = 0; i < attributes.length; ++i) {
           const attr = attributes[i];
           UI.UIUtils.createTextChild(tagElement, ' ');
-          this._buildAttributeDOM(tagElement, attr.name, attr.value, updateRecord, false, node);
+          /* COHERENT_BEGIN */
+          const attrElement = this._buildAttributeDOM(tagElement, attr.name, attr.value, updateRecord, false, node);
+          if (attr.name.startsWith('data-')) attrElements.push({ element: attrElement, name: attr.name });
+        }
+
+        if (attributes.find((attr) => attr.name.startsWith('data-'))) {
+          node.domModel().getDataBindingDataForNode(node.id).then((data) => {
+            for (let i = 0; i < attrElements.length; ++i) {
+              const attrElement = attrElements[i];
+              const showAttributeError = data?.dataBindAttributes.find(({ attributeName, mutators }) =>
+                attributeName === attrElement.name &&
+                mutators.find((mutator) => mutator.compilationError || mutator.parsingError ||
+                  mutator.evaluationNodes.find((evalNode) => evalNode.evaluationError))
+              );
+              attrElement.element.classList.toggle('attribute-error-background', !!showAttributeError);
+              attrElement.element.querySelector('.data-attr-error')?.classList.toggle('hidden', !showAttributeError);
+            }
+          });
+          /* COHERENT_END */
         }
       }
       if (updateRecord) {

--- a/front_end/panels/elements/ElementsTreeOutline.ts
+++ b/front_end/panels/elements/ElementsTreeOutline.ts
@@ -37,16 +37,19 @@
 import * as Common from '../../core/common/common.js';
 import * as i18n from '../../core/i18n/i18n.js';
 import * as SDK from '../../core/sdk/sdk.js';
+import * as Protocol from '../../generated/protocol.js';
 import * as UI from '../../ui/legacy/legacy.js';
 /* COHERENT_BEGIN */
+import * as ElementsComponents from './components/components.js';
 import { PopoverRequest } from '../../ui/legacy/PopoverHelper.js';
+type BindAttributeTargetElement = HTMLElement & { attrName: string, domModel: SDK.DOMModel.DOMModel, nodeId: Protocol.DOM.NodeId };
 /* COHERENT_END */
 
-import {linkifyDeferredNodeReference} from './DOMLinkifier.js';
-import {ElementsPanel} from './ElementsPanel.js';
-import {ElementsTreeElement, InitialChildrenLimit} from './ElementsTreeElement.js';
-import {ImagePreviewPopover} from './ImagePreviewPopover.js';
-import type {MarkerDecoratorRegistration} from './MarkerDecorator.js';
+import { linkifyDeferredNodeReference } from './DOMLinkifier.js';
+import { ElementsPanel } from './ElementsPanel.js';
+import { ElementsTreeElement, InitialChildrenLimit } from './ElementsTreeElement.js';
+import { ImagePreviewPopover } from './ImagePreviewPopover.js';
+import type { MarkerDecoratorRegistration } from './MarkerDecorator.js';
 
 const UIStrings = {
   /**
@@ -70,6 +73,9 @@ const UIStrings = {
    * @description A context menu item to open the badge settings pane
    */
   adornerSettings: 'Badge settings\u2026',
+  /* COHERENT_BEGIN */
+  noDataForBindAttribute: 'There is no data for the selected attribute'
+  /* COHERENT_END */
 };
 const str_ = i18n.i18n.registerUIStrings('panels/elements/ElementsTreeOutline.ts', UIStrings);
 const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
@@ -82,19 +88,19 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
   _shadowRoot: ShadowRoot;
   _element: HTMLElement;
   _includeRootDOMNode: boolean;
-  _selectEnabled: boolean|undefined;
-  _rootDOMNode: SDK.DOMModel.DOMNode|null;
-  _selectedDOMNode: SDK.DOMModel.DOMNode|null;
+  _selectEnabled: boolean | undefined;
+  _rootDOMNode: SDK.DOMModel.DOMNode | null;
+  _selectedDOMNode: SDK.DOMModel.DOMNode | null;
   _visible: boolean;
   _imagePreviewPopover: ImagePreviewPopover;
   _updateRecords: Map<SDK.DOMModel.DOMNode, UpdateRecord>;
   _treeElementsBeingUpdated: Set<ElementsTreeElement>;
-  decoratorExtensions: MarkerDecoratorRegistration[]|null;
+  decoratorExtensions: MarkerDecoratorRegistration[] | null;
   _showHTMLCommentsSetting: Common.Settings.Setting<boolean>;
-  _multilineEditing?: MultilineEditorController|null;
+  _multilineEditing?: MultilineEditorController | null;
   _visibleWidth?: number;
   _clipboardNodeData?: ClipboardData;
-  _isXMLMimeType?: boolean|null;
+  _isXMLMimeType?: boolean | null;
   suppressRevealAndSelect: boolean = false;
   _previousHoveredElement?: UI.TreeOutline.TreeElement;
   _treeElementBeingDragged?: ElementsTreeElement;
@@ -102,6 +108,10 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
   _updateModifiedNodesTimeout?: number;
   /* COHERENT_BEGIN */
   _popoverHelper: UI.PopoverHelper.PopoverHelper;
+  _dataBindTreeElement: ElementsComponents.DataBindingProperty.DataBindAttributeTreeElement | null = null;
+  _bindAttributeHoveredElement: BindAttributeTargetElement | null = null;
+  _popoverMessageElement: Element | null = null;
+  _onBindingModelsSynchronizedBound: () => Promise<void>
   /* COHERENT_END */
 
   constructor(omitRootDOMNode?: boolean, selectEnabled?: boolean, hideGutter?: boolean) {
@@ -109,14 +119,21 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     this.treeElementByNode = new WeakMap();
     const shadowContainer = document.createElement('div');
     this._shadowRoot = UI.Utils.createShadowRootWithCoreStyles(
-        shadowContainer, {cssFile: 'panels/elements/elementsTreeOutline.css', delegatesFocus: undefined});
+      shadowContainer, { cssFile: 'panels/elements/elementsTreeOutline.css', delegatesFocus: undefined });
     const outlineDisclosureElement = this._shadowRoot.createChild('div', 'elements-disclosure');
     /* COHERENT_BEGIN */
     this._popoverHelper = new UI.PopoverHelper.PopoverHelper(
       this.element,
       this._requestPopover.bind(this),
+      [
+        'panels/elements/components/dataBindingProperty.css',
+        'ui/legacy/treeoutline.css',
+        'ui/legacy/components/object_ui/objectValue.css',
+        'ui/legacy/components/object_ui/objectPropertiesSection.css',
+        'panels/elements/dataBindingPanel.css'
+      ]
     );
-    this._popoverHelper.setTimeout(0, 0);
+    this._popoverHelper.setTimeout(0, 200);
     /* COHERENT_END */
     this._element = this.element;
     this._element.classList.add('elements-tree-outline', 'source-code');
@@ -139,6 +156,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     this._element.addEventListener('clipboard-cut', this._onCopyOrCut.bind(this, true), false);
     this._element.addEventListener('clipboard-paste', this._onPaste.bind(this), false);
     this._element.addEventListener('keydown', this._onKeyDown.bind(this), false);
+    this._onBindingModelsSynchronizedBound = this._onBindingModelsSynchronized.bind(this);
 
     outlineDisclosureElement.appendChild(this._element);
     this.element = shadowContainer;
@@ -151,27 +169,27 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     this._visible = false;
 
     this._imagePreviewPopover = new ImagePreviewPopover(
-        this.contentElement,
-        event => {
-          let link: (Element|null) = (event.target as Element | null);
-          while (link && !ImagePreviewPopover.getImageURL(link)) {
-            link = link.parentElementOrShadowHost();
-          }
-          return link;
-        },
-        link => {
-          const listItem = UI.UIUtils.enclosingNodeOrSelfWithNodeName(link, 'li');
-          if (!listItem) {
-            return null;
-          }
+      this.contentElement,
+      event => {
+        let link: (Element | null) = (event.target as Element | null);
+        while (link && !ImagePreviewPopover.getImageURL(link)) {
+          link = link.parentElementOrShadowHost();
+        }
+        return link;
+      },
+      link => {
+        const listItem = UI.UIUtils.enclosingNodeOrSelfWithNodeName(link, 'li');
+        if (!listItem) {
+          return null;
+        }
 
-          const treeElement =
-              (UI.TreeOutline.TreeElement.getTreeElementBylistItemNode(listItem) as ElementsTreeElement | undefined);
-          if (!treeElement) {
-            return null;
-          }
-          return treeElement.node();
-        });
+        const treeElement =
+          (UI.TreeOutline.TreeElement.getTreeElementBylistItemNode(listItem) as ElementsTreeElement | undefined);
+        if (!treeElement) {
+          return null;
+        }
+        return treeElement.node();
+      });
 
     this._updateRecords = new Map();
     this._treeElementsBeingUpdated = new Set();
@@ -183,32 +201,114 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     this.useLightSelectionColor();
   }
 
-  static forDOMModel(domModel: SDK.DOMModel.DOMModel): ElementsTreeOutline|null {
+  static forDOMModel(domModel: SDK.DOMModel.DOMModel): ElementsTreeOutline | null {
     return elementsTreeOutlineByDOMModel.get(domModel) || null;
   }
   /* COHERENT_BEGIN */
+  createInfo(textContent: string, className?: string): Element {
+    const classNameOrDefault = className || 'gray-info-message';
+    const info = this.contentElement.createChild('div', classNameOrDefault);
+    info.textContent = textContent;
+    return info;
+  }
+
   _requestPopover(event: MouseEvent): PopoverRequest | null {
+    const hightlightBindingAttributesSetting = Common.Settings.Settings.instance().moduleSetting('highlightBindingAttributes').get();
+    if (!hightlightBindingAttributesSetting) return null;
+
     const target = event.target as HTMLElement;
-    if (!target?.classList.contains('data-bind-expression')) {
+    let targetEl = null as BindAttributeTargetElement | null;
+    if (target.classList.contains('webkit-html-attribute-value') || target.classList.contains('webkit-html-attribute-name')) {
+      targetEl = target.parentElement as BindAttributeTargetElement;
+    }
+
+    if (!targetEl?.classList.contains('data-bind-expression')) {
       return null;
     }
 
     return {
-      box: target.boxInWindow(),
-      show: (popover: UI.GlassPane.GlassPane) => {
+      box: targetEl.boxInWindow(),
+      show: async (popover: UI.GlassPane.GlassPane) => {
+        if (popover._maxSize) popover._maxSize.width = 500;
+        if (popover._maxSize) popover._maxSize.height = 500;
+
+        this._bindAttributeHoveredElement = targetEl;
+        const data = await this._bindAttributeHoveredElement?.domModel.getDataBindingDataForNode(this._bindAttributeHoveredElement.nodeId) as Protocol.DOM.GetDataBindingDataForNodeResponse;
+        const attributesData = data ? data.dataBindAttributes : null;
         const container = document.createElement('div');
         container.classList.add('bind-expression-popover');
+        container.classList.add('data-binding-panel-base');
 
-        const rawExpr = target.textContent || '';
-        const expr = rawExpr.replace(/^\{\{|\}\}$/g, '');
+        this._popoverMessageElement = this.createInfo(i18nString(UIStrings.noDataForBindAttribute), 'hidden gray-info-message');
+        container.appendChild(this._popoverMessageElement);
+        if (!attributesData) {
+          this._popoverMessageElement.classList.remove('hidden');
+          popover.contentElement.appendChild(container);
+          return Promise.resolve(true);
+        }
 
-        container.textContent = `Evaluated: ${expr}`;
+        const attributeData = attributesData.find((attr) => attr.attributeName === this._bindAttributeHoveredElement?.attrName);
+        if (!attributeData) {
+          this._popoverMessageElement.classList.remove('hidden');
+          container.appendChild(this._popoverMessageElement);
+          popover.contentElement.appendChild(container);
+          return Promise.resolve(true);
+        }
+
+        const treeElement = this.contentElement.createChild('div', 'bind-tree');
+        const treeOutline = new UI.TreeOutline.TreeOutlineInShadow();
+        treeOutline.contentElement.classList.add('tree-outline');
+
+        treeElement.appendChild(treeOutline.contentElement);
+        this._dataBindTreeElement = new ElementsComponents.DataBindingProperty.DataBindAttributeTreeElement(attributeData);
+        SDK.TargetManager.TargetManager.instance().addModelListener(
+          SDK.DOMModel.DOMModel, SDK.DOMModel.Events.DataBindingModelsSynchronized, this._onBindingModelsSynchronized, this);
+        await this._dataBindTreeElement.expandRecursively();
+
+        treeOutline.appendChild(this._dataBindTreeElement)
+        container.appendChild(treeElement);
 
         popover.contentElement.appendChild(container);
         return Promise.resolve(true);
+      },
+      hide: () => {
+        SDK.TargetManager.TargetManager.instance().removeModelListener(
+          SDK.DOMModel.DOMModel, SDK.DOMModel.Events.DataBindingModelsSynchronized, this._onBindingModelsSynchronized, this);
+        this._dataBindTreeElement = null;
       }
     };
   }
+
+  async _onBindingModelsSynchronized() {
+    // If for some reason the hide callback has been not triggered already we need to do a check here
+    if (!this._popoverHelper.isPopoverVisible()) {
+      SDK.TargetManager.TargetManager.instance().removeModelListener(
+        SDK.DOMModel.DOMModel, SDK.DOMModel.Events.DataBindingModelsSynchronized, this._onBindingModelsSynchronized, this);
+      this._dataBindTreeElement = null;
+      return;
+    }
+
+    const data = await this._bindAttributeHoveredElement?.domModel.getDataBindingDataForNode(this._bindAttributeHoveredElement?.nodeId as Protocol.DOM.NodeId) as Protocol.DOM.GetDataBindingDataForNodeResponse;
+    const attributesData = data ? data.dataBindAttributes : null;
+
+    if (!attributesData) {
+      this._popoverMessageElement?.classList.remove('hidden');
+      this._dataBindTreeElement?.listItemElement.classList.add('hidden');
+      return;
+    }
+
+    const attributeData = attributesData.find((attr) => attr.attributeName === this._bindAttributeHoveredElement?.attrName);
+    if (!attributeData) {
+      this._popoverMessageElement?.classList.remove('hidden');
+      this._dataBindTreeElement?.listItemElement.classList.add('hidden');
+      return;
+    }
+
+    this._popoverMessageElement?.classList.add('hidden');
+    this._dataBindTreeElement?.listItemElement.classList.remove('hidden');
+    this._dataBindTreeElement?.update(attributeData);
+  }
+
   /* COHERENT_END */
   _onShowHTMLCommentsChange(): void {
     const selectedNode = this.selectedDOMNode();
@@ -222,7 +322,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     this._element.classList.toggle('elements-tree-nowrap', !wrap);
   }
 
-  setMultilineEditing(multilineEditing: MultilineEditorController|null): void {
+  setMultilineEditing(multilineEditing: MultilineEditorController | null): void {
     this._multilineEditing = multilineEditing;
   }
 
@@ -237,7 +337,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     }
   }
 
-  _setClipboardData(data: ClipboardData|null): void {
+  _setClipboardData(data: ClipboardData | null): void {
     if (this._clipboardNodeData) {
       const treeElement = this.findTreeElement(this._clipboardNodeData.node);
       if (treeElement) {
@@ -298,7 +398,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     this.performCopyOrCut(isCut, targetNode);
   }
 
-  performCopyOrCut(isCut: boolean, node: SDK.DOMModel.DOMNode|null): void {
+  performCopyOrCut(isCut: boolean, node: SDK.DOMModel.DOMNode | null): void {
     if (!node) {
       return;
     }
@@ -307,7 +407,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     }
 
     node.copyNode();
-    this._setClipboardData({node: node, isCut: isCut});
+    this._setClipboardData({ node: node, isCut: isCut });
   }
 
   canPaste(targetNode: SDK.DOMModel.DOMNode): boolean {
@@ -367,7 +467,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     }
 
     function expandCallback(
-        this: ElementsTreeOutline, error: string|null, pastedNode: SDK.DOMModel.DOMNode|null): void {
+      this: ElementsTreeOutline, error: string | null, pastedNode: SDK.DOMModel.DOMNode | null): void {
       if (error || !pastedNode) {
         return;
       }
@@ -407,11 +507,11 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     }
   }
 
-  get rootDOMNode(): SDK.DOMModel.DOMNode|null {
+  get rootDOMNode(): SDK.DOMModel.DOMNode | null {
     return this._rootDOMNode;
   }
 
-  set rootDOMNode(x: SDK.DOMModel.DOMNode|null) {
+  set rootDOMNode(x: SDK.DOMModel.DOMNode | null) {
     if (this._rootDOMNode === x) {
       return;
     }
@@ -427,11 +527,11 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     return Boolean(this._isXMLMimeType);
   }
 
-  selectedDOMNode(): SDK.DOMModel.DOMNode|null {
+  selectedDOMNode(): SDK.DOMModel.DOMNode | null {
     return this._selectedDOMNode;
   }
 
-  selectDOMNode(node: SDK.DOMModel.DOMNode|null, focus?: boolean): void {
+  selectDOMNode(node: SDK.DOMModel.DOMNode | null, focus?: boolean): void {
     if (this._selectedDOMNode === node) {
       this._revealAndSelectNode(node, !focus);
       return;
@@ -487,14 +587,14 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
 
   _selectedNodeChanged(focus: boolean): void {
     this.dispatchEventToListeners(
-        ElementsTreeOutline.Events.SelectedNodeChanged, {node: this._selectedDOMNode, focus: focus});
+      ElementsTreeOutline.Events.SelectedNodeChanged, { node: this._selectedDOMNode, focus: focus });
   }
 
   _fireElementsTreeUpdated(nodes: SDK.DOMModel.DOMNode[]): void {
     this.dispatchEventToListeners(ElementsTreeOutline.Events.ElementsTreeUpdated, nodes);
   }
 
-  findTreeElement(node: SDK.DOMModel.DOMNode): ElementsTreeElement|null {
+  findTreeElement(node: SDK.DOMModel.DOMNode): ElementsTreeElement | null {
     let treeElement = this._lookUpTreeElement(node);
     if (!treeElement && node.nodeType() === Node.TEXT_NODE) {
       // The text node might have been inlined if it was short, so try to find the parent element.
@@ -504,7 +604,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     return /** @type {?ElementsTreeElement} */ treeElement as ElementsTreeElement | null;
   }
 
-  _lookUpTreeElement(node: SDK.DOMModel.DOMNode|null): UI.TreeOutline.TreeElement|null {
+  _lookUpTreeElement(node: SDK.DOMModel.DOMNode | null): UI.TreeOutline.TreeElement | null {
     if (!node) {
       return null;
     }
@@ -543,7 +643,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     return this.treeElementByNode.get(node) || null;
   }
 
-  createTreeElementFor(node: SDK.DOMModel.DOMNode): ElementsTreeElement|null {
+  createTreeElementFor(node: SDK.DOMModel.DOMNode): ElementsTreeElement | null {
     let treeElement = this.findTreeElement(node);
     if (treeElement) {
       return treeElement;
@@ -556,7 +656,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     return treeElement ? this._showChild(treeElement, node) : null;
   }
 
-  _revealAndSelectNode(node: SDK.DOMModel.DOMNode|null, omitFocus: boolean): void {
+  _revealAndSelectNode(node: SDK.DOMModel.DOMNode | null, omitFocus: boolean): void {
     if (this.suppressRevealAndSelect) {
       return;
     }
@@ -575,7 +675,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     treeElement.revealAndSelect(omitFocus);
   }
 
-  _treeElementFromEvent(event: MouseEvent): UI.TreeOutline.TreeElement|null {
+  _treeElementFromEvent(event: MouseEvent): UI.TreeOutline.TreeElement | null {
     const scrollContainer = this.element.parentElement;
     if (!scrollContainer) {
       return null;
@@ -617,7 +717,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     element.select();
   }
 
-  setHoverEffect(treeElement: UI.TreeOutline.TreeElement|null): void {
+  setHoverEffect(treeElement: UI.TreeOutline.TreeElement | null): void {
     if (this._previousHoveredElement === treeElement) {
       return;
     }
@@ -641,19 +741,19 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
 
     this.setHoverEffect(element);
     this._highlightTreeElement(
-        (element as UI.TreeOutline.TreeElement), !UI.KeyboardShortcut.KeyboardShortcut.eventHasEitherCtrlOrMeta(event));
+      (element as UI.TreeOutline.TreeElement), !UI.KeyboardShortcut.KeyboardShortcut.eventHasEitherCtrlOrMeta(event));
   }
 
   _highlightTreeElement(element: UI.TreeOutline.TreeElement, showInfo: boolean): void {
     if (element instanceof ElementsTreeElement) {
       element.node().domModel().overlayModel().highlightInOverlay(
-          {node: element.node(), selectorList: undefined}, 'all', showInfo);
+        { node: element.node(), selectorList: undefined }, 'all', showInfo);
       return;
     }
 
     if (element instanceof ShortcutTreeElement) {
       element.domModel().overlayModel().highlightInOverlay(
-          {deferredNode: element.deferredNode(), selectorList: undefined}, 'all', showInfo);
+        { deferredNode: element.deferredNode(), selectorList: undefined }, 'all', showInfo);
     }
   }
 
@@ -662,7 +762,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     SDK.OverlayModel.OverlayModel.hideDOMNodeHighlight();
   }
 
-  _ondragstart(event: DragEvent): boolean|undefined {
+  _ondragstart(event: DragEvent): boolean | undefined {
     const node = (event.target as Node | null);
     if (!node || node.hasSelection()) {
       return false;
@@ -702,7 +802,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
       return false;
     }
 
-    let node: (SDK.DOMModel.DOMNode|null) = (treeElement.node() as SDK.DOMModel.DOMNode | null);
+    let node: (SDK.DOMModel.DOMNode | null) = (treeElement.node() as SDK.DOMModel.DOMNode | null);
     while (node) {
       if (node === this._treeElementBeingDragged._node) {
         return false;
@@ -725,7 +825,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     return false;
   }
 
-  _validDragSourceOrTarget(treeElement: UI.TreeOutline.TreeElement|null): ElementsTreeElement|null {
+  _validDragSourceOrTarget(treeElement: UI.TreeOutline.TreeElement | null): ElementsTreeElement | null {
     if (!treeElement) {
       return null;
     }
@@ -773,7 +873,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     }
     const wasExpanded = this._treeElementBeingDragged.expanded;
     this._treeElementBeingDragged._node.moveTo(
-        parentNode, anchorNode, this.selectNodeAfterEdit.bind(this, wasExpanded));
+      parentNode, anchorNode, this.selectNodeAfterEdit.bind(this, wasExpanded));
 
     delete this._treeElementBeingDragged;
   }
@@ -810,13 +910,13 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     if (!node) {
       return;
     }
-    let textNode: Element|null = node.enclosingNodeOrSelfWithClass('webkit-html-text-node');
+    let textNode: Element | null = node.enclosingNodeOrSelfWithClass('webkit-html-text-node');
     if (textNode && textNode.classList.contains('bogus')) {
       textNode = null;
     }
     const commentNode = node.enclosingNodeOrSelfWithClass('webkit-html-comment');
     contextMenu.saveSection().appendItem(
-        i18nString(UIStrings.storeAsGlobalVariable), this._saveNodeToTempVariable.bind(this, treeElement.node()));
+      i18nString(UIStrings.storeAsGlobalVariable), this._saveNodeToTempVariable.bind(this, treeElement.node()));
     if (textNode) {
       treeElement.populateTextContextMenu(contextMenu, textNode);
     } else if (isTag) {
@@ -838,7 +938,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
   async _saveNodeToTempVariable(node: SDK.DOMModel.DOMNode): Promise<void> {
     const remoteObjectForConsole = await node.resolveToObject();
     await SDK.ConsoleModel.ConsoleModel.instance().saveToTempVariable(
-        UI.Context.Context.instance().flavor(SDK.RuntimeModel.ExecutionContext), remoteObjectForConsole);
+      UI.Context.Context.instance().flavor(SDK.RuntimeModel.ExecutionContext), remoteObjectForConsole);
   }
 
   runPendingUpdates(): void {
@@ -867,7 +967,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
       }
       if (keyboardEvent.key === 'ArrowDown' && node.nextSibling) {
         node.moveTo(
-            node.parentNode, node.nextSibling.nextSibling, this.selectNodeAfterEdit.bind(this, treeElement.expanded));
+          node.parentNode, node.nextSibling.nextSibling, this.selectNodeAfterEdit.bind(this, treeElement.expanded));
         keyboardEvent.consume(true);
         return;
       }
@@ -922,8 +1022,8 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     }
   }
 
-  selectNodeAfterEdit(wasExpanded: boolean, error: string|null, newNode: SDK.DOMModel.DOMNode|null): ElementsTreeElement
-      |null {
+  selectNodeAfterEdit(wasExpanded: boolean, error: string | null, newNode: SDK.DOMModel.DOMNode | null): ElementsTreeElement
+    | null {
     if (error) {
       return null;
     }
@@ -967,12 +1067,12 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     }
 
     await object.callFunction(
-        (toggleClassAndInjectStyleRule as (this: Object, ...arg1: unknown[]) => void),
-        [{value: pseudoType}, {value: !hidden}]);
+      (toggleClassAndInjectStyleRule as (this: Object, ...arg1: unknown[]) => void),
+      [{ value: pseudoType }, { value: !hidden }]);
     object.release();
     node.setMarker('hidden-marker', hidden ? null : true);
 
-    function toggleClassAndInjectStyleRule(this: Element, pseudoType: string|null, hidden: boolean): void {
+    function toggleClassAndInjectStyleRule(this: Element, pseudoType: string | null, hidden: boolean): void {
       const classNamePrefix = '__web-inspector-hide';
       const classNameSuffix = '-shortcut__';
       const styleTagId = '__web-inspector-hide-shortcut-style__';
@@ -987,7 +1087,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
       const className = classNamePrefix + (pseudoType || '') + classNameSuffix;
       this.classList.toggle(className, hidden);
 
-      let localRoot: Element|HTMLHeadElement = this;
+      let localRoot: Element | HTMLHeadElement = this;
       while (localRoot.parentNode) {
         localRoot = (localRoot.parentNode as Element);
       }
@@ -1056,7 +1156,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     return record;
   }
 
-  _updateRecordForHighlight(node: SDK.DOMModel.DOMNode): UpdateRecord|null {
+  _updateRecordForHighlight(node: SDK.DOMModel.DOMNode): UpdateRecord | null {
     if (!this._visible) {
       return null;
     }
@@ -1071,14 +1171,14 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     }
   }
 
-  _attributeModified(event: Common.EventTarget.EventTargetEvent<{node: SDK.DOMModel.DOMNode, name: string}>): void {
-    const {node} = event.data;
+  _attributeModified(event: Common.EventTarget.EventTargetEvent<{ node: SDK.DOMModel.DOMNode, name: string }>): void {
+    const { node } = event.data;
     this._addUpdateRecord(node).attributeModified(event.data.name);
     this._updateModifiedNodesSoon();
   }
 
-  _attributeRemoved(event: Common.EventTarget.EventTargetEvent<{node: SDK.DOMModel.DOMNode, name: string}>): void {
-    const {node} = event.data;
+  _attributeRemoved(event: Common.EventTarget.EventTargetEvent<{ node: SDK.DOMModel.DOMNode, name: string }>): void {
+    const { node } = event.data;
     this._addUpdateRecord(node).attributeRemoved(event.data.name);
     this._updateModifiedNodesSoon();
   }
@@ -1099,9 +1199,9 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     this._updateModifiedNodesSoon();
   }
 
-  _nodeRemoved(event: Common.EventTarget.EventTargetEvent<{node: SDK.DOMModel.DOMNode, parent: SDK.DOMModel.DOMNode}>):
-      void {
-    const {node, parent} = event.data;
+  _nodeRemoved(event: Common.EventTarget.EventTargetEvent<{ node: SDK.DOMModel.DOMNode, parent: SDK.DOMModel.DOMNode }>):
+    void {
+    const { node, parent } = event.data;
     this.resetClipboardIfNeeded(node);
     this._addUpdateRecord(parent).nodeRemoved(node);
     this._updateModifiedNodesSoon();
@@ -1206,14 +1306,14 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     const treeElement = new ElementsTreeElement(node, isClosingTag);
     treeElement.setExpandable(!isClosingTag && this._hasVisibleChildren(node));
     if (node.nodeType() === Node.ELEMENT_NODE && node.parentNode && node.parentNode.nodeType() === Node.DOCUMENT_NODE &&
-        !node.parentNode.parentNode) {
+      !node.parentNode.parentNode) {
       treeElement.setCollapsible(false);
     }
     treeElement.selectable = Boolean(this._selectEnabled);
     return treeElement;
   }
 
-  _showChild(treeElement: ElementsTreeElement, child: SDK.DOMModel.DOMNode): ElementsTreeElement|null {
+  _showChild(treeElement: ElementsTreeElement, child: SDK.DOMModel.DOMNode): ElementsTreeElement | null {
     if (treeElement.isClosingTag()) {
       return null;
     }
@@ -1305,7 +1405,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     function handleLoadAllChildren(this: ElementsTreeOutline, event: Event): void {
       const visibleChildCount = this._visibleChildren(treeElement.node()).length;
       this.setExpandedChildrenLimit(
-          treeElement, Math.max(visibleChildCount, treeElement.expandedChildrenLimit() + InitialChildrenLimit));
+        treeElement, Math.max(visibleChildCount, treeElement.expandedChildrenLimit() + InitialChildrenLimit));
       event.consume();
     }
   }
@@ -1340,8 +1440,8 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
   }
 
   insertChildElement(
-      treeElement: ElementsTreeElement, child: SDK.DOMModel.DOMNode, index: number,
-      isClosingTag?: boolean): ElementsTreeElement {
+    treeElement: ElementsTreeElement, child: SDK.DOMModel.DOMNode, index: number,
+    isClosingTag?: boolean): ElementsTreeElement {
     const newElement = this._createElementTreeElement(child, isClosingTag);
     treeElement.insertChild(newElement, index);
     return newElement;
@@ -1374,7 +1474,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
 
     // Remove any tree elements that no longer have this node as their parent and save
     // all existing elements that could be reused. This also removes closing tag element.
-    const existingTreeElements = new Map<SDK.DOMModel.DOMNode, UI.TreeOutline.TreeElement&ElementsTreeElement>();
+    const existingTreeElements = new Map<SDK.DOMModel.DOMNode, UI.TreeOutline.TreeElement & ElementsTreeElement>();
     for (let i = treeElement.childCount() - 1; i >= 0; --i) {
       const existingTreeElement = treeElement.childAt(i);
       if (!(existingTreeElement instanceof ElementsTreeElement)) {
@@ -1421,7 +1521,7 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
       }
       treeElement.insertChild(treeElement.expandAllButtonElement, targetButtonIndex);
       treeElement.expandAllButtonElement.title =
-          i18nString(UIStrings.showAllNodesDMore, {PH1: visibleChildren.length - expandedChildCount});
+        i18nString(UIStrings.showAllNodesDMore, { PH1: visibleChildren.length - expandedChildCount });
     } else if (treeElement.expandAllButtonElement) {
       treeElement.expandAllButtonElement = null;
     }
@@ -1530,12 +1630,12 @@ export class UpdateRecord {
 
   isAttributeModified(attributeName: string): boolean {
     return this._modifiedAttributes !== null && this._modifiedAttributes !== undefined &&
-        this._modifiedAttributes.has(attributeName);
+      this._modifiedAttributes.has(attributeName);
   }
 
   hasRemovedAttributes(): boolean {
     return this._removedAttributes !== null && this._removedAttributes !== undefined &&
-        Boolean(this._removedAttributes.size);
+      Boolean(this._removedAttributes.size);
   }
 
   isCharDataModified(): boolean {
@@ -1555,9 +1655,9 @@ let rendererInstance: Renderer;
 
 export class Renderer implements UI.UIUtils.Renderer {
   static instance(opts: {
-    forceNew: boolean|null,
-  } = {forceNew: null}): Renderer {
-    const {forceNew} = opts;
+    forceNew: boolean | null,
+  } = { forceNew: null }): Renderer {
+    const { forceNew } = opts;
     if (!rendererInstance || forceNew) {
       rendererInstance = new Renderer();
     }
@@ -1566,9 +1666,9 @@ export class Renderer implements UI.UIUtils.Renderer {
 
   async render(object: Object): Promise<{
     node: Node,
-    tree: UI.TreeOutline.TreeOutline|null,
-  }|null> {
-    let node: SDK.DOMModel.DOMNode|(SDK.DOMModel.DOMNode | null)|null = null;
+    tree: UI.TreeOutline.TreeOutline | null,
+  } | null> {
+    let node: SDK.DOMModel.DOMNode | (SDK.DOMModel.DOMNode | null) | null = null;
 
     if (object instanceof SDK.DOMModel.DOMNode) {
       node = (object as SDK.DOMModel.DOMNode);
@@ -1592,7 +1692,7 @@ export class Renderer implements UI.UIUtils.Renderer {
     // @ts-ignore used in console_test_runner
     treeOutline.element.treeElementForTest = firstChild;
     treeOutline.setShowSelectionOnKeyboardFocus(/* show: */ true, /* preventTabOrder: */ true);
-    return {node: treeOutline.element, tree: treeOutline};
+    return { node: treeOutline.element, tree: treeOutline };
   }
 }
 
@@ -1643,7 +1743,7 @@ export class ShortcutTreeElement extends UI.TreeOutline.TreeElement {
     }
     this._nodeShortcut.deferredNode.highlight();
     this._nodeShortcut.deferredNode.resolve(resolved.bind(this));
-    function resolved(this: ShortcutTreeElement, node: SDK.DOMModel.DOMNode|null): void {
+    function resolved(this: ShortcutTreeElement, node: SDK.DOMModel.DOMNode | null): void {
       if (node && this.treeOutline instanceof ElementsTreeOutline) {
         this.treeOutline._selectedDOMNode = node;
         this.treeOutline._selectedNodeChanged(false);

--- a/front_end/panels/elements/ElementsTreeOutline.ts
+++ b/front_end/panels/elements/ElementsTreeOutline.ts
@@ -50,6 +50,7 @@ import { ElementsPanel } from './ElementsPanel.js';
 import { ElementsTreeElement, InitialChildrenLimit } from './ElementsTreeElement.js';
 import { ImagePreviewPopover } from './ImagePreviewPopover.js';
 import type { MarkerDecoratorRegistration } from './MarkerDecorator.js';
+const EPSILON = 1; // pixel tolerance for float rounding
 
 const UIStrings = {
   /**
@@ -212,6 +213,29 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
     return info;
   }
 
+  getLineRects(element: BindAttributeTargetElement) {
+    const rects = Array.from(element.getClientRects());
+    if (rects.length === 0) return [];
+
+    // Group rects that belong to the same visual line (by top Y)
+    const lines = [];
+    rects.sort((a, b) => a.top - b.top);
+
+    for (const rect of rects) {
+      const last = lines.length ? lines[lines.length - 1] : null;
+      if (last && Math.abs(last.top - rect.top) < EPSILON) {
+        // Merge rects from the same line horizontally
+        last.left = Math.min(last.left, rect.left);
+        last.right = Math.max(last.right, rect.right);
+        last.width = last.right - last.left;
+      } else {
+        lines.push({ x: rect.x, y: rect.y, width: rect.width, height: rect.height, left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom });
+      }
+    }
+
+    return lines;
+  }
+
   _requestPopover(event: MouseEvent): PopoverRequest | null {
     const hightlightBindingAttributesSetting = Common.Settings.Settings.instance().moduleSetting('highlightBindingAttributes').get();
     if (!hightlightBindingAttributesSetting) return null;
@@ -226,8 +250,18 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
       return null;
     }
 
+    const attributeElementRects = this.getLineRects(targetEl);
+    const activeRect = attributeElementRects.find(rect =>
+      event.clientY >= rect.top - EPSILON &&
+      event.clientY <= rect.bottom + EPSILON &&
+      event.clientX >= rect.left - EPSILON &&
+      event.clientX <= rect.right + EPSILON
+    );
+    const targetElBB = targetEl.boxInWindow();
+    const attributeBB = new AnchorBox(activeRect?.x || targetElBB.x, activeRect?.y || targetElBB.y, activeRect?.width || targetElBB.width, activeRect?.height || targetElBB.height);
+
     return {
-      box: targetEl.boxInWindow(),
+      box: attributeBB,
       show: async (popover: UI.GlassPane.GlassPane) => {
         if (popover._maxSize) popover._maxSize.width = 500;
         if (popover._maxSize) popover._maxSize.height = 500;

--- a/front_end/panels/elements/components/DataBindingProperty.ts
+++ b/front_end/panels/elements/components/DataBindingProperty.ts
@@ -16,20 +16,14 @@ const str_ = i18n.i18n.registerUIStrings('panels/accessibility/AccessibilityNode
 const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
 
 export class DataBindBaseTreeElement extends UI.TreeOutline.TreeElement {
-  private warningMark: UI.UIUtils.DevToolsIconLabel;
-  public executionContext: SDK.RuntimeModel.ExecutionContext | undefined
-  constructor(executionContext?: SDK.RuntimeModel.ExecutionContext | undefined) {
+  private mark: UI.UIUtils.DevToolsIconLabel;
+  constructor() {
     super('');
     this.selectable = false;
     this.setExpandable(true);
-    this.executionContext = executionContext;
-    this.setDisableSelectFocus(true);
-    this.warningMark = this.createExclamationMark('');
-    this.listItemElement.insertBefore(this.warningMark, this.listItemElement.firstChild);
-  }
-
-  setWarningMarkTip(tip: string) {
-    this.warningMark.title = tip;
+    this.setDisableSelectFocus(true)
+    this.mark = this.createMark('');
+    this.listItemElement.insertBefore(this.mark, this.listItemElement.firstChild);
   }
 
   async evalExpression(expr: string | undefined) {
@@ -41,16 +35,19 @@ export class DataBindBaseTreeElement extends UI.TreeOutline.TreeElement {
     return await executionContext?.evaluate({ expression: expr, returnByValue: true }, false, true);
   }
 
-  createExclamationMark(tooltip: string): UI.UIUtils.DevToolsIconLabel {
-    const exclamationElement = document.createElement('span', { is: 'dt-icon-label' }) as UI.UIUtils.DevToolsIconLabel;
-    exclamationElement.type = 'smallicon-warning';
-    exclamationElement.className = 'hidden';
-    UI.Tooltip.Tooltip.install(exclamationElement, tooltip);
-    return exclamationElement;
+  createMark(tooltip: string): UI.UIUtils.DevToolsIconLabel {
+    const markElement = document.createElement('span', { is: 'dt-icon-label' }) as UI.UIUtils.DevToolsIconLabel;
+    markElement.type = '';
+    markElement.className = 'hidden';
+    UI.Tooltip.Tooltip.install(markElement, tooltip);
+    return markElement;
   }
 
-  toggleExclamationMark(visible: boolean) {
-    this.warningMark?.classList.toggle('hidden', !visible);
+  toggleMark(visible: boolean, type = 'error', tip = '') {
+    const newType = `smallicon-${type}`;
+    this.mark.type = this.mark.type !== newType ? newType : this.mark.type;
+    this.mark.title = tip;
+    this.mark?.classList.toggle('hidden', !visible);
   }
 
   appendSpanElement(parent: Element, textContent: string, className?: string): HTMLSpanElement {
@@ -136,20 +133,24 @@ export class DataBindNodeTreeElement extends DataBindBaseTreeElement {
   public value?: string;
   public valueType?: string;
   public dataBindNodeInfoTree: DataBindNodeInfoTreeElement;
-  constructor(expression: string, value: string, valueType: string, evaluationError: string | undefined, syncStatus: boolean, executionContext?: SDK.RuntimeModel.ExecutionContext | undefined) {
-    super(executionContext);
+  constructor(expression: string, value: string, valueType: string, evaluationError: string | undefined, syncStatus: boolean) {
+    super();
 
     this.listItemElement.classList.add('monospace');
     this.listItemElement.classList.add('expressions-list');
     this.dataBindNodeInfoTree = new DataBindNodeInfoTreeElement(evaluationError, syncStatus);
 
-    this.setWarningMarkTip('Warnings generated while evaluating the expression');
     this.createElements();
     this.update(expression, value, valueType, evaluationError, syncStatus);
   }
 
   update(expression: string, value: string, valueType: string, evaluationError: string | undefined, syncStatus: boolean) {
-    this.toggleExclamationMark(!!evaluationError || !syncStatus);
+    if (!!evaluationError) {
+      this.toggleMark(true, 'error', 'Errors generated while evaluating the expression');
+    } else if (!syncStatus) {
+      this.toggleMark(true, 'warning', 'Warnings generated while evaluating the expression');
+    } else this.toggleMark(false);
+
     if (expression !== this.expression) this.expressionElement!.textContent = expression;
     if (value !== this.value) {
       this.valueElement!.textContent = value;
@@ -185,11 +186,10 @@ export class DataBindAttributeTreeElement extends DataBindBaseTreeElement {
   private dataBindNodeElements: DataBindNodeTreeElement[] = []
   private statusInterval: any;
 
-  constructor(attributeData: Protocol.DOM.DataBindAttributeData, executionContext: SDK.RuntimeModel.ExecutionContext | undefined) {
-    super(executionContext);
+  constructor(attributeData: Protocol.DOM.DataBindAttributeData) {
+    super();
 
     this.listItemElement.classList.add('bind-attribute');
-    this.setWarningMarkTip('Warnings generated while parsing the attribute');
     this.attributeNameElement = this.appendSpanElement(this.listItemElement, '', 'object-value-string name');
     this.appendSeparatorElement(this.listItemElement);
     this.attributeValueElement = this.appendSpanElement(this.listItemElement, '', 'object-value-string');
@@ -216,7 +216,11 @@ export class DataBindAttributeTreeElement extends DataBindBaseTreeElement {
     //@ts-ignore
     const outOfSync = exprValue?.object?.value as unknown !== currentValue;
     node.dataBindNodeInfoTree.updateStatus(!outOfSync);
-    node.toggleExclamationMark(outOfSync);
+    if (!!node?.dataBindNodeInfoTree?.evaluationError) {
+      node?.toggleMark(true, 'error', 'Errors generated while parsing the attribute');
+    } else if (outOfSync) {
+      node?.toggleMark(true, 'warning', 'Warnings generated while parsing the attribute');
+    } else node?.toggleMark(false);
 
     return outOfSync;
   }
@@ -238,8 +242,14 @@ export class DataBindAttributeTreeElement extends DataBindBaseTreeElement {
       if (await this.updateNodeStatus(node)) hasNonSyncStatus = true;
     }
 
-    this.dataBindNodeElements[0].dataBindNodeInfoTree.updateStatus(!hasNonSyncStatus);
-    this.dataBindNodeElements[0].toggleExclamationMark(hasNonSyncStatus);
+    const rootElement = this.dataBindNodeElements[0];
+    rootElement?.dataBindNodeInfoTree?.updateStatus(!hasNonSyncStatus);
+
+    if (!!rootElement?.dataBindNodeInfoTree?.evaluationError) {
+      rootElement?.toggleMark(true, 'error', 'Errors generated while parsing the attribute');
+    } else if (hasNonSyncStatus) {
+      rootElement?.toggleMark(true, 'warning', 'Warnings generated while parsing the attribute');
+    } else rootElement?.toggleMark(false);
   }
 
   startTimers() {
@@ -275,7 +285,8 @@ export class DataBindAttributeTreeElement extends DataBindBaseTreeElement {
 
   private updateMutators(attributeData: Protocol.DOM.DataBindAttributeData) {
     const mutatorsErrors = [] as string[];
-    let nodeHasProblem = false;
+    let nodeHasError = false;
+    let nodeHasWarning = false;
 
     for (const mutator of attributeData.mutators) {
       if (mutator.parsingError) {
@@ -291,10 +302,11 @@ export class DataBindAttributeTreeElement extends DataBindBaseTreeElement {
 
       for (let i = 0; i < evalNodes.length; i++) {
         const { evaluatableExpression, evaluatedValue, evaluationError, syncStatus, valueType } = evalNodes[i];
-        if (!!evaluationError || !syncStatus) nodeHasProblem = true;
+        if (!!evaluationError) nodeHasError = true;
+        if (!syncStatus) nodeHasWarning = true;
 
         if (!this.dataBindNodeElements[i]) {
-          const node = new DataBindNodeTreeElement(evaluatableExpression, evaluatedValue, valueType, evaluationError, syncStatus, this.executionContext);
+          const node = new DataBindNodeTreeElement(evaluatableExpression, evaluatedValue, valueType, evaluationError, syncStatus);
           this.appendChild(node);
           this.dataBindNodeElements[i] = node;
           continue;
@@ -312,7 +324,12 @@ export class DataBindAttributeTreeElement extends DataBindBaseTreeElement {
       }
     }
 
-    this.toggleExclamationMark(mutatorsErrors.length > 0 || nodeHasProblem);
+    if (nodeHasWarning) {
+      this.toggleMark(true, 'warning', 'Warnings generated while parsing the attribute');
+    } else if (nodeHasError || mutatorsErrors.length > 0) {
+      this.toggleMark(true, 'error', 'Errors generated while parsing the attribute');
+    }
+
     this.errorsContainerElement.classList.toggle('hidden', mutatorsErrors.length === 0);
     this.errorsContainerElement.innerHTML = '';
     if (mutatorsErrors.length > 0) {
@@ -321,7 +338,7 @@ export class DataBindAttributeTreeElement extends DataBindBaseTreeElement {
   }
 
   update(attributeData: Protocol.DOM.DataBindAttributeData) {
-    this.toggleExclamationMark(false);
+    this.toggleMark(false);
 
     if (attributeData.attributeName !== this.attributeData?.attributeName) {
       this.attributeNameElement.textContent = attributeData.attributeName;

--- a/front_end/panels/elements/components/DataBindingProperty.ts
+++ b/front_end/panels/elements/components/DataBindingProperty.ts
@@ -302,7 +302,7 @@ export class DataBindAttributeTreeElement extends DataBindBaseTreeElement {
 
       for (let i = 0; i < evalNodes.length; i++) {
         const { evaluatableExpression, evaluatedValue, evaluationError, syncStatus, valueType } = evalNodes[i];
-        if (!!evaluationError) nodeHasError = true;
+        if (evaluationError) nodeHasError = true;
         if (!syncStatus) nodeHasWarning = true;
 
         if (!this.dataBindNodeElements[i]) {

--- a/front_end/panels/elements/components/dataBindingProperty.css
+++ b/front_end/panels/elements/components/dataBindingProperty.css
@@ -20,13 +20,14 @@
 }
 
 .status-ok {
-    color: green;
+    color: var(--color-accent-green);
 }
 
 .bind-warning-message,
 .bind-error-message {
     user-select: text;
     cursor: text;
+    padding: 0 4px 0 4px;
 }
 
 .bind-error-message.mutators {
@@ -34,13 +35,13 @@
 }
 
 .bind-error-message {
-    color: rgb(255 0 0);
-    background-color: rgb(255, 240, 240);
+    color: var(--override-error-text-color);
+    background-color: var(--override-console-error-background-color);
 }
 
 .bind-warning-message {
-    color: rgb(92, 60, 0);
-    background-color: rgb(255, 245, 194);
+    color: var(--override-console-warning-text-color);
+    background-color: var(--override-console-warning-background-color);
 }
 
 .expressions-list {

--- a/front_end/panels/elements/dataBindingPanel.css
+++ b/front_end/panels/elements/dataBindingPanel.css
@@ -4,6 +4,24 @@
 
 .bind-tree {
     margin-top: 3px;
+    --override-error-text-color: var(--color-error-text);
+    --override-console-error-background-color: var(--color-error-background);
+    --override-error-border-color: var(--color-error-border);
+    --override-message-border-color: rgb(240 240 240);
+    --override-warning-border-color: hsl(50deg 100% 88%);
+    --override-focused-message-border-color: hsl(214deg 67% 88%);
+    --override-focused-message-background-color: hsl(214deg 48% 95%);
+    --override-console-warning-background-color: hsl(50deg 100% 95%);
+    --override-console-warning-text-color: hsl(39deg 100% 18%);
+}
+
+:host-context(.-theme-with-dark-background) .bind-tree {
+    --override-message-border-color: rgb(58 58 58);
+    --override-warning-border-color: rgb(102 85 0);
+    --override-focused-message-border-color: hsl(214deg 47% 48%);
+    --override-focused-message-background-color: hsl(214deg 19% 20%);
+    --override-console-warning-background-color: hsl(50deg 100% 10%);
+    --override-console-warning-text-color: hsl(39deg 89% 55%);
 }
 
 .data-binding-panel-base {
@@ -30,6 +48,10 @@
     background-color: var(--color-background-elevation-1);
     z-index: 2;
     padding: 0;
+}
+
+.toolbar.second {
+    top: 27px;
 }
 
 .gray-info-message {

--- a/front_end/panels/elements/elements-meta.ts
+++ b/front_end/panels/elements/elements-meta.ts
@@ -212,6 +212,12 @@ UI.ViewManager.registerViewExtension({
 });
 
 /* COHERENT_BEGIN */
+Common.Settings.registerSettingExtension({
+  settingName: 'highlightBindingAttributes',
+  settingType: Common.Settings.SettingType.BOOLEAN,
+  defaultValue: false,
+});
+
 UI.ViewManager.registerViewExtension({
   location: UI.ViewManager.ViewLocationValues.ELEMENTS_SIDEBAR,
   id: 'elements.data-binding-sidebar',

--- a/front_end/ui/legacy/Geometry.ts
+++ b/front_end/ui/legacy/Geometry.ts
@@ -353,11 +353,17 @@ export const boundsForTransformedPoints = function(matrix: DOMMatrix, points: nu
 };
 
 export class Size {
-  width: number;
+  _width: number;
   height: number;
   constructor(width: number, height: number) {
-    this.width = width;
+    this._width = width;
     this.height = height;
+  }
+
+  get width() { return this._width }
+
+  set width(value: number) {
+    this.width = value;
   }
 
   clipTo(size?: Size|null): Size {

--- a/front_end/ui/legacy/Geometry.ts
+++ b/front_end/ui/legacy/Geometry.ts
@@ -363,7 +363,7 @@ export class Size {
   get width() { return this._width }
 
   set width(value: number) {
-    this.width = value;
+    this._width = value;
   }
 
   clipTo(size?: Size|null): Size {

--- a/front_end/ui/legacy/PopoverHelper.ts
+++ b/front_end/ui/legacy/PopoverHelper.ts
@@ -46,7 +46,10 @@ export class PopoverHelper {
   _boundMouseDown: (event: Event) => void;
   _boundMouseMove: (ev: Event) => void;
   _boundMouseOut: (event: Event) => void;
-  constructor(container: Element, getRequest: (arg0: MouseEvent) => PopoverRequest | null) {
+  /* COHERENT_BEGIN */
+  _additionalPopoverCSSFiles: string[]
+  constructor(container: Element, getRequest: (arg0: MouseEvent) => PopoverRequest | null, additionalCSSFiles?: string[]) {
+  /* COHERENT_END */
     this._disableOnClick = false;
     this._hasPadding = false;
     this._getRequest = getRequest;
@@ -57,6 +60,9 @@ export class PopoverHelper {
     this._hideTimeout = 0;
     this._hidePopoverTimer = null;
     this._showPopoverTimer = null;
+    /* COHERENT_BEGIN */
+    this._additionalPopoverCSSFiles = additionalCSSFiles ||[];
+    /* COHERENT_END */
     this._boundMouseDown = this._mouseDown.bind(this);
     this._boundMouseMove = this._mouseMove.bind(this);
     this._boundMouseOut = this._mouseOut.bind(this);
@@ -192,6 +198,11 @@ export class PopoverHelper {
   _showPopover(document: Document): void {
     const popover = new GlassPane();
     popover.registerRequiredCSS('ui/legacy/popover.css');
+    /* COHERENT_BEGIN */
+    this._additionalPopoverCSSFiles.forEach((file) => {
+      popover.registerRequiredCSS(file);
+    });
+    /* COHERENT_END */
     popover.setSizeBehavior(SizeBehavior.MeasureContent);
     popover.setMarginBehavior(MarginBehavior.Arrow);
     const request = this._scheduledRequest;

--- a/front_end/ui/legacy/PopoverHelper.ts
+++ b/front_end/ui/legacy/PopoverHelper.ts
@@ -61,7 +61,7 @@ export class PopoverHelper {
     this._hidePopoverTimer = null;
     this._showPopoverTimer = null;
     /* COHERENT_BEGIN */
-    this._additionalPopoverCSSFiles = additionalCSSFiles ||[];
+    this._additionalPopoverCSSFiles = additionalCSSFiles || [];
     /* COHERENT_END */
     this._boundMouseDown = this._mouseDown.bind(this);
     this._boundMouseMove = this._mouseMove.bind(this);

--- a/front_end/ui/legacy/inspectorCommon.css
+++ b/front_end/ui/legacy/inspectorCommon.css
@@ -42,6 +42,7 @@
   --legacy-item-selection-bg-color: #cfe8fc;
   --legacy-item-selection-inactive-bg-color: #e0e0e0;
   --item-hover-color: rgb(56 121 217 / 10%);
+  --bind-attribute-hover-color: var(--item-hover-color);
   --monospace-font-size: 10px;
   --monospace-font-family: monospace;
   --source-code-font-size: 11px;
@@ -71,6 +72,7 @@
   --legacy-focus-ring-inactive-shadow: 0 0 0 1px var(--legacy-focus-ring-inactive-shadow-color);
   --legacy-item-selection-bg-color: hsl(207deg 88% 22%);
   --legacy-item-selection-inactive-bg-color: #454545;
+  --bind-attribute-hover-color: rgb(113 119 124 / 31%);
 }
 
 body {

--- a/front_end/ui/legacy/inspectorSyntaxHighlight.css
+++ b/front_end/ui/legacy/inspectorSyntaxHighlight.css
@@ -354,6 +354,6 @@
 
 /* COHERENT_BEGIN */
 .data-bind-expression:hover {
-  background-color: var(--item-hover-color);
+  background-color: var(--bind-attribute-hover-color);
 }
 /* COHERENT_END */

--- a/front_end/ui/legacy/inspectorSyntaxHighlight.css
+++ b/front_end/ui/legacy/inspectorSyntaxHighlight.css
@@ -205,6 +205,11 @@
   word-break: break-all;
 }
 
+.attribute-error-background {
+  background-color: var(--color-error-background);
+  text-decoration-line: spelling-error;
+}
+
 .devtools-link {
   color: var(--color-link);
   text-decoration: underline;
@@ -349,7 +354,6 @@
 
 /* COHERENT_BEGIN */
 .data-bind-expression:hover {
-  color: HighlightText;
-  background-color: Highlight;
+  background-color: var(--item-hover-color);
 }
 /* COHERENT_END */

--- a/front_end/ui/legacy/themeColors.css
+++ b/front_end/ui/legacy/themeColors.css
@@ -56,6 +56,7 @@
   --color-accent-green: rgb(24 128 56);
   --color-green: rgb(99 172 190);
   --color-link: var(--color-primary);
+  --color-attribute-error: rgb(255 0 0 / 8%);
   --color-syntax-1: rgb(200 0 0);
   --color-syntax-2: rgb(136 18 128);
   --color-syntax-3: rgb(26 26 166);
@@ -158,6 +159,7 @@
   --color-syntax-6: rgb(137 137 137);
   --color-syntax-7: rgb(207 208 208);
   --color-syntax-8: rgb(93 176 215);
+  --color-attribute-error: rgb(255 0 0 / 39%);
   --drop-shadow:
     0 0 0 1px rgb(255 255 255 / 20%),
     0 2px 4px 2px rgb(0 0 0 / 20%),


### PR DESCRIPTION
<img width="1494" height="368" alt="image" src="https://github.com/user-attachments/assets/44a0ea66-3c17-4658-8cb8-99502b9745eb" />

Currently, there’s a minor issue where, if an attribute (e.g. `data-bind-style-top`) wraps onto the next line, the popover won’t appear when hovering another attribute (e.g. `data-bind-style-left`) that lies within the red bounding box. This limitation comes from the Inspector’s popover behavior and cannot be easily fixed at the moment.

The issue occurs because once the popover is opened for an element, it remains active as long as the mouse stays within that element’s bounding box. However, when an element spans multiple lines, its bounding box (indicated by the red border in the image) becomes larger, covering other attributes and preventing new popovers from being triggered.

### The issue has been fixed!!!

I have also added an option to disable the tips in the data binding tab.

build: https://192.168.88.10:7001/sharing/CGnkU7w5z