### PR TITLE
Fix/data binding warnings

### DIFF
--- a/front_end/core/sdk/DOMModel.ts
+++ b/front_end/core/sdk/DOMModel.ts
@@ -1495,8 +1495,10 @@ export class DOMModel extends SDKModel<EventTypes> {
     return this.nodeForId(containerNodeId);
   }
 
-  async getDataBindingDataForNode(nodeId: Protocol.DOM.NodeId): Promise<Protocol.DOM.GetDataBindingDataForNodeResponse|null> {
-    const response = await this.agent.invoke_getDataBindingDataForNode({nodeId});
+  async getDataBindingDataForNode(nodeId?: Protocol.DOM.NodeId, nodeType?: number, nodeName?: string): Promise<Protocol.DOM.GetDataBindingDataForNodeResponse | null> {
+    if (!nodeId || nodeType !== Node.ELEMENT_NODE || nodeName === 'DATABINDMETA' || !this.nodeForId(nodeId)) return null;
+
+    const response = await this.agent.invoke_getDataBindingDataForNode({ nodeId });
     if (response.getError()) {
       return null;
     }

--- a/front_end/panels/elements/DataBindingSidebarPane.ts
+++ b/front_end/panels/elements/DataBindingSidebarPane.ts
@@ -217,9 +217,11 @@ export class DataBindingSidebarPane extends ElementsSidebarPane {
   }
 
   async doUpdate(): Promise<void> {
-    if (!this.node()) return this.showMessage(this.noSelectedNodeInfo);
-    const domModel = this.node()?.domModel();
-    const data = await domModel?.getDataBindingDataForNode(this.node()!.id);
+    const node = this.node();
+    if (!node) return this.showMessage(this.noSelectedNodeInfo);
+
+    const domModel = node.domModel();
+    const data = await domModel?.getDataBindingDataForNode(node.id, node.nodeType(), node.nodeName());
     if (!data) return this.showMessage(this.fetchDataWarning);
 
     const attributes = data?.dataBindAttributes || [];

--- a/front_end/panels/elements/ElementsTreeElement.ts
+++ b/front_end/panels/elements/ElementsTreeElement.ts
@@ -1506,6 +1506,10 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
       attrSpanElement.attrName = name;
       //@ts-ignore
       attrSpanElement.nodeId = this._node.id;
+      //@ts-ignore
+      attrSpanElement._nodeName = this._node.nodeName();
+      //@ts-ignore
+      attrSpanElement._nodeType = this._node.nodeType();
     }
     /* COHERENT_END */
 
@@ -1648,7 +1652,7 @@ export class ElementsTreeElement extends UI.TreeOutline.TreeElement {
         }
 
         if (attributes.find((attr) => attr.name.startsWith('data-'))) {
-          node.domModel().getDataBindingDataForNode(node.id).then((data) => {
+          node.domModel().getDataBindingDataForNode(node.id, node.nodeType(), node.nodeName()).then((data) => {
             for (let i = 0; i < attrElements.length; ++i) {
               const attrElement = attrElements[i];
               const showAttributeError = data?.dataBindAttributes?.find(({ attributeName, mutators }) =>

--- a/front_end/panels/elements/ElementsTreeOutline.ts
+++ b/front_end/panels/elements/ElementsTreeOutline.ts
@@ -42,7 +42,7 @@ import * as UI from '../../ui/legacy/legacy.js';
 /* COHERENT_BEGIN */
 import * as ElementsComponents from './components/components.js';
 import { PopoverRequest } from '../../ui/legacy/PopoverHelper.js';
-type BindAttributeTargetElement = HTMLElement & { attrName: string, domModel: SDK.DOMModel.DOMModel, nodeId: Protocol.DOM.NodeId };
+type BindAttributeTargetElement = HTMLElement & { attrName: string, domModel: SDK.DOMModel.DOMModel, nodeId: Protocol.DOM.NodeId, _nodeName: string, _nodeType: number };
 /* COHERENT_END */
 
 import { linkifyDeferredNodeReference } from './DOMLinkifier.js';
@@ -267,7 +267,8 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
         if (popover._maxSize) popover._maxSize.height = 500;
 
         this._bindAttributeHoveredElement = targetEl;
-        const data = await this._bindAttributeHoveredElement?.domModel.getDataBindingDataForNode(this._bindAttributeHoveredElement.nodeId) as Protocol.DOM.GetDataBindingDataForNodeResponse;
+        const { nodeId, _nodeType, _nodeName } = this._bindAttributeHoveredElement || {};
+        const data = await this._bindAttributeHoveredElement?.domModel.getDataBindingDataForNode(nodeId, _nodeType, _nodeName) as Protocol.DOM.GetDataBindingDataForNodeResponse;
         const attributesData = data ? data.dataBindAttributes : null;
         const container = document.createElement('div');
         container.classList.add('bind-expression-popover');
@@ -322,7 +323,8 @@ export class ElementsTreeOutline extends UI.TreeOutline.TreeOutline {
       return;
     }
 
-    const data = await this._bindAttributeHoveredElement?.domModel.getDataBindingDataForNode(this._bindAttributeHoveredElement?.nodeId as Protocol.DOM.NodeId) as Protocol.DOM.GetDataBindingDataForNodeResponse;
+    const { nodeId, _nodeType, _nodeName } = this._bindAttributeHoveredElement || {};
+    const data = await this._bindAttributeHoveredElement?.domModel.getDataBindingDataForNode(nodeId, _nodeType, _nodeName) as Protocol.DOM.GetDataBindingDataForNodeResponse;
     const attributesData = data ? data.dataBindAttributes : null;
 
     if (!attributesData) {

--- a/front_end/panels/elements/components/DataBindingProperty.ts
+++ b/front_end/panels/elements/components/DataBindingProperty.ts
@@ -221,7 +221,9 @@ export class DataBindNodeTreeElement extends DataBindBaseTreeElement {
 
     if (expression !== this.expression) this.expressionElement!.textContent = expression;
     if (value !== this.value) {
-      this.valueElement!.textContent = value;
+      this.valueElement!.textContent = valueType === 'string' ? '\"' : '';
+      this.valueElement!.textContent += value;
+      this.valueElement!.textContent += valueType === 'string' ? '\"' : '';
       if (this.valueElement) this.valueElement.className = `object-value-${valueType}`;
     }
 

--- a/third_party/blink/public/devtools_protocol/browser_protocol.pdl
+++ b/third_party/blink/public/devtools_protocol/browser_protocol.pdl
@@ -2676,7 +2676,9 @@ domain DOM
   # attribute of the selected node 
   command getDataBindingDataForNode
     parameters
-      NodeId nodeId
+      optional NodeId nodeId
+      optional number nodeType
+      optional string nodeName
     returns
       array of DataBindAttributeData dataBindAttributes
 


### PR DESCRIPTION
The warning `DOM.getDataBindingDataForNode: Node not an element - coh node id` has been resolved by verifying that the node type is element before attempting to retrieve binding data. Additionally, data retrieval for `<databindmeta>` elements has been skipped - they report the correct type but still produce warnings.

The warning `DOM.getDataBindingDataForNode: Could not find node with given node id` has been significantly reduced and now appears only in rare cases. This is handled by checking whether a node exists for the given ID before calling `getDataBindingDataForNode`, preventing unnecessary log spam.

String values in the Data Binding panel are now correctly wrapped in quotation marks ("").